### PR TITLE
Complete AI & bug fix

### DIFF
--- a/mods/sp/rules/ai.yaml
+++ b/mods/sp/rules/ai.yaml
@@ -1,51 +1,61 @@
 Player:
 	ModularBot@EasyAI:
-		Name: Easy AI
+		Name: EasyAI
 		Type: EasyAI
 	ModularBot@Cheater:
-		Name: Cheater AI
+		Name: CheaterAI
 		Type: CheaterAI
+	ModularBot@ShatteredAI:
+		Name: ShatteredAI
+		Type: ShatteredAI
 	GrantConditionOnBotOwner@AIReload:
 		Condition: AIReload
-		Bots: CheaterAI, EasyAI
+		Bots: CheaterAI, EasyAI, ShatteredAI
+	GrantConditionOnBotOwner@AIEasy:
+		Condition: AIEasy
+		Bots: EasyAI
 	GrantConditionOnBotOwner@AICheater:
 		Condition: AICheater
 		Bots: CheaterAI
+	GrantConditionOnBotOwner@AIShattered:
+		Condition: AIShattered
+		Bots: ShatteredAI
 	HarvesterBotModule:
-		RequiresCondition: AIReload || AICheater
+		RequiresCondition: AIReload
 		HarvesterTypes: harv, scrharv
 		RefineryTypes: gdiref, nodref, scrproc, cabproc, muproc
-	BaseBuilderBotModule@AIReload:
-		RequiresCondition: AIReload || AICheater
-		MinimumExcessPower: 30
-		MaximumExcessPower: 200
-		ExcessPowerIncrement: 30
+	BaseBuilderBotModule@AINormal:
+		RequiresCondition: AIReload && !AIShattered
+		MinimumExcessPower: 90
+		MaximumExcessPower: 250
+		ExcessPowerIncrement: 50
 		ExcessPowerIncreaseThreshold: 4
+		NewProductionCashThreshold: 0
 		ConstructionYardTypes: gacnst, drached, cabyard, nodyard, mutyard
 		RefineryTypes: gdiref, nodref, scrproc, cabproc, muproc
 		PowerTypes: gapowr, napowor, naapwr, cabpowr, mutpowr, scrpowr
 		BarracksTypes: gapile, nahand, mutrax, cabrax, scrrax
-		VehiclesFactoryTypes: gaweap, naweap, mutweap, cabweap, scrweap
-		ProductionTypes: gapile, nahand, mutrax, cabclaw, scrrax, gaweap, naweap, mutweap, cabweap, scrweap, gahpad, nahpad, muair, cabair, scrair
+		VehiclesFactoryTypes: gaweap, naweap, muweap, cabweap, scrweap
+		ProductionTypes: gapile, nahand, mutrax, cabclaw, scrrax, gaweap, naweap, muweap, cabweap, scrweap, gahpad, nahpad, muair, cabair, scrair
 		SiloTypes: gasilo
 		BuildingLimits:
 			gadept: 1
 			scrdepot: 1
-			gdiref: 3
-			nodref: 3
-			scrproc: 3
-			cabproc: 3
-			muproc: 3
+			gdiref: 2
+			nodref: 2
+			scrproc: 2
+			cabproc: 2
+			muproc: 2
 			gasilo: 0
-			napowr: 12
-			naapwr: 3
-			gapowr: 12
-			mupowr: 14
+			napowr: 8
+			naapwr: 5
+			gapowr: 15
+			mupowr: 11
 			cabpowr: 12
 			scrpowr: 12
 			gapile: 2
 			nahand: 2
-			murax: 3
+			murax: 2
 			cabclaw: 2
 			scrrax: 2
 			gaweap: 2
@@ -60,60 +70,66 @@ Player:
 			scrradr: 1
 			gatech: 1
 			natech: 1
-			muthall: 1
+			muhall: 1
 			scrtech: 1
 			cabtech: 1
 			gavulc: 8
 			cabpit: 8
-			mubunkrfull: 5
+			mubunkrfull: 7
 			nalasr: 8
 			scrneedler: 8
 			muflak: 7
+			mucannon: 7
 			gacsam: 7
 			nasam: 7
 			cabrail: 7
 			scrtractor: 7
-			cabblast: 5
-			garock: 5
-			naobel: 5
-			scrdrone: 5
-			gafire: 2
-			cabeye: 2
-			scrextractor: 3
-			nahpad: 2
-			gahpad: 2
-			muair: 2
-			scrair: 2
-			cabair: 2
+			cabblast: 8
+			garock: 8
+			naobel: 7
+			scrdrone: 7
+			cabeye: 1
+			scrextractor: 2
+			nahpad: 4
+			gahpad: 4
+			muair: 4
+			scrair: 3
+			cabair: 3
 			gaplug: 1
 			natmpl: 1
 			mutsw1: 1
 			cabsw1: 1
 			scrsw1: 1
+			nastlh: 1
+			gtdrop: 1
+			scradvpowr: 1
+			namisl: 1
+			mutsw2: 1
+			cabobelisk: 1
 		BuildingFractions:
-			gadept: 100
-			scrdepot: 100
-			gdiref: 99
-			nodref: 99
-			scrproc: 99
-			cabproc: 99
-			muproc: 99
-			napowr: 30
-			naapwr: 30
-			gapowr: 30
-			mupowr: 30
-			cabpowr: 30
-			scrpowr: 30
-			gapile: 5
-			nahand: 5
-			murax: 5
-			cabclaw: 5
-			scrrax: 5
-			gaweap: 5
-			cabweap: 5
-			naweap: 5
-			muweap: 5
-			scrweap: 5
+			gadept: 1
+			scrdepot: 1
+			gdiref: 100
+			nodref: 100
+			scrproc: 100
+			cabproc: 100
+			muproc: 100
+			napowr: 15
+			naapwr: 15
+			gapowr: 15
+			mupowr: 35
+			cabpowr: 15
+			scrpowr: 15
+			gapile: 10
+			nahand: 10
+			murax: 10
+			cabclaw: 10
+			scrrax: 10
+			gaweap: 60
+			cabweap: 60
+			naweap: 60
+			muweap: 60
+			scrweap: 60
 			garadr: 1
 			naradr: 1
 			cabradr: 1
@@ -121,29 +137,29 @@ Player:
 			scrradr: 1
 			gatech: 1
 			natech: 1
-			muthall: 1
+			muhall: 1
 			scrtech: 1
 			cabtech: 1
 			gavulc: 10
-			gacsam: 10
+			gacsam: 8
 			nalasr: 10
 			nasam: 10
 			cabpit: 10
 			cabrail: 10
 			mubunkrfull: 10
 			muflak: 10
+			mucannon: 10
 			scrneedler: 10
 			scrtractor: 10
-			cabblast: 5
-			garock: 5
-			naobel: 5
-			scrdrone: 5
-			gafire: 1
+			cabblast: 10
+			garock: 10
+			naobel: 10
+			scrdrone: 10
 			cabeye: 1
-			scrextrator: 1
-			nahpad: 5
-			gahpad: 5
-			muair: 5
+			scrextractor: 3
+			nahpad: 10
+			gahpad: 10
+			muair: 10
 			scrair: 5
 			cabair: 5
 			gaplug: 1
@@ -151,98 +167,354 @@ Player:
 			mutsw1: 1
 			cabsw1: 1
 			scrsw1: 1
-	BuildingRepairBotModule:
-		RequiresCondition: AIReload || AICheater
-	SquadManagerBotModule@test:
-		RequiresCondition: AIReload || AICheater
-		SquadSize: 15
-		SquadSizeRandomBonus: 15
-		ExcludeFromSquadsTypes: harv, cabharv, scrharv, harv.gdi, harv.nod, harv.mut, harv.cab, engineer, e2, swarmling, shapeshifter
+			nastlh: 1
+			gtdrop: 1
+			scradvpowr: 1
+			namisl: 1
+			mutsw2: 1
+			cabobelisk: 1
+		BuildingDelays:
+			gaplug: 30000
+			natmpl: 30000
+			mutsw1: 30000
+			cabsw1: 30000
+			scrsw1: 30000
+			nastlh: 10000
+			gtdrop: 21000
+			scradvpowr: 21000
+			namisl: 21000
+			mutsw2: 21000
+			cabobelisk: 21000
+			garadr: 4000
+			naradr: 3000
+			cabradr: 4000
+			muradr: 5000
+			scrradr: 2000
+			gatech: 7000
+			natech: 6000
+			muhall: 7500
+			scrtech: 6000
+			cabtech: 6000
+			nalasr: 3500
+			gadept: 6000
+	BaseBuilderBotModule@AIShattered:
+		RequiresCondition: AIShattered
+		MinimumExcessPower: 90
+		MaximumExcessPower: 250
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		NewProductionCashThreshold: 0
 		ConstructionYardTypes: gacnst, drached, cabyard, nodyard, mutyard
+		RefineryTypes: gdiref, nodref, scrproc, cabproc, muproc
+		PowerTypes: gapowr, napowor, naapwr, cabpowr, mutpowr, scrpowr
+		BarracksTypes: gapile, nahand, mutrax, cabrax, scrrax
+		VehiclesFactoryTypes: gaweap, naweap, muweap, cabweap, scrweap
+		ProductionTypes: gapile, nahand, mutrax, cabclaw, scrrax, gaweap, naweap, muweap, cabweap, scrweap, gahpad, nahpad, muair, cabair, scrair
+		SiloTypes: gasilo
+		BuildingLimits:
+			gadept: 1
+			scrdepot: 1
+			gdiref: 2
+			nodref: 2
+			scrproc: 2
+			cabproc: 2
+			muproc: 2
+			gasilo: 0
+			napowr: 11
+			naapwr: 7
+			gapowr: 20
+			mupowr: 22
+			cabpowr: 22
+			scrpowr: 22
+			gapile: 7
+			nahand: 7
+			murax: 7
+			cabclaw: 7
+			scrrax: 7
+			gaweap: 4
+			cabweap: 4
+			naweap: 4
+			muweap: 4
+			scrweap: 4
+			garadr: 1
+			naradr: 1
+			cabradr: 1
+			muradr: 1
+			scrradr: 1
+			gatech: 1
+			natech: 1
+			muhall: 1
+			scrtech: 1
+			cabtech: 1
+			gavulc: 8
+			cabpit: 8
+			mubunkrfull: 7
+			nalasr: 8
+			scrneedler: 8
+			muflak: 7
+			mucannon: 7
+			gacsam: 7
+			nasam: 7
+			cabrail: 7
+			scrtractor: 7
+			cabblast: 8
+			garock: 8
+			naobel: 7
+			scrdrone: 7
+			cabeye: 3
+			scrextractor: 2
+			nahpad: 7
+			gahpad: 7
+			muair: 7
+			scrair: 7
+			cabair: 7
+			gaplug: 1
+			natmpl: 1
+			mutsw1: 1
+			cabsw1: 1
+			scrsw1: 1
+			nastlh: 3
+			gtdrop: 1
+			scradvpowr: 1
+			namisl: 1
+			mutsw2: 1
+			cabobelisk: 1
+		BuildingFractions:
+			gadept: 1
+			scrdepot: 1
+			gdiref: 100
+			nodref: 100
+			scrproc: 100
+			cabproc: 100
+			muproc: 100
+			napowr: 15
+			naapwr: 15
+			gapowr: 15
+			mupowr: 35
+			cabpowr: 15
+			scrpowr: 15
+			gapile: 10
+			nahand: 10
+			murax: 10
+			cabclaw: 10
+			scrrax: 10
+			gaweap: 60
+			cabweap: 60
+			naweap: 60
+			muweap: 60
+			scrweap: 60
+			garadr: 1
+			naradr: 1
+			cabradr: 1
+			muradr: 1
+			scrradr: 1
+			gatech: 1
+			natech: 1
+			muhall: 1
+			scrtech: 1
+			cabtech: 1
+			gavulc: 10
+			gacsam: 8
+			nalasr: 10
+			nasam: 10
+			cabpit: 10
+			cabrail: 10
+			mubunkrfull: 10
+			muflak: 10
+			mucannon: 10
+			scrneedler: 10
+			scrtractor: 10
+			cabblast: 10
+			garock: 10
+			naobel: 10
+			scrdrone: 10
+			cabeye: 1
+			scrextractor: 3
+			nahpad: 10
+			gahpad: 10
+			muair: 10
+			scrair: 10
+			cabair: 10
+			gaplug: 1
+			natmpl: 1
+			mutsw1: 1
+			cabsw1: 1
+			scrsw1: 1
+			nastlh: 1
+			gtdrop: 1
+			scradvpowr: 1
+			namisl: 1
+			mutsw2: 1
+			cabobelisk: 1
+		BuildingDelays:
+			gaplug: 30000
+			natmpl: 30000
+			mutsw1: 30000
+			cabsw1: 30000
+			scrsw1: 30000
+			nastlh: 10000
+			gtdrop: 21000
+			scradvpowr: 21000
+			namisl: 21000
+			mutsw2: 21000
+			cabobelisk: 21000
+			garadr: 4000
+			naradr: 3000
+			cabradr: 4000
+			muradr: 5000
+			scrradr: 2000
+			gatech: 7000
+			natech: 6000
+			muhall: 7500
+			scrtech: 6000
+			cabtech: 6000
+			gadept: 6000
+	BuildingRepairBotModule:
+		RequiresCondition: AIReload
+	SquadManagerBotModule@test:
+		RequiresCondition: AIReload
+		SquadSize: 35
+		SquadSizeRandomBonus: 30
+		ExcludeFromSquadsTypes: harv, cabharv, scrharv, harv.gdi, harv.nod, harv.mut, harv.cab, engineer, e2, swarmling, shapeshifter,mcv, drache, drache_bot, cabmcv, nodmcv, mutmcv, repairvehicle
+		ConstructionYardTypes: gacnst, drached, cabyard, nodyard, mutyard
+		DangerScanRadius: 18
+		AttackForceInterval: 50
+		RushInterval : 20000
+		MinimumAttackForceDelay: 2500
+		ProtectUnitScanRadius: 16
+		AssignRolesInterval: 75
+		IdleScanRadius: 15
+		AttackScanRadius :20
 	UnitBuilderBotModule@test:
-		RequiresCondition: AIReload || AICheater
-		UnitQueues: Infantry, Vehicle, Air, Defense, Building
-		IdleBaseUnitsMaximum: 30
+		RequiresCondition: AIReload
+		UnitQueues: Infantry, Vehicle, Air
+		IdleBaseUnitsMaximum: 60
 		UnitsToBuild:
-			harv: 40
-			scrharv: 40
-			cabharv: 40
-			gdie1: 20
-			altnode1: 20
-			pdrone: 20
-			shark: 20
+			harv: 90
+			scrharv: 90
+			cabharv: 90
+			gdie1: 10
+			altnode1: 5
+			pdrone: 5
+			shark: 1
 			jumpjetair: 10
 			crusader: 10
-			e3: 10
+			e3: 1
 			marauder: 10
 			cabsentry: 10
-			cyborg: 10
-			cborg: 10
-			legio: 10
-			grenadier: 20
-			medic: 20
-			templar: 20
-			mutfiend: 20
+			cyborg: 15
+			cborg: 15
+			legio: 20
+			grenadier: 10
+			medic: 5
+			templar: 10
+			mutfiend: 3
 			reapercab: 20
-			colossi: 20
+			colossi: 5
 			seer: 10
-			eagleguard: 30
+			eagleguard: 10
 			bhs: 30
-			psyker: 30
+			psyker: 10
 			glad: 30
 			cyc2: 30
 			float: 3
 			bug: 30
 			mmch: 50
-			smech: 70
-			bggy: 50
-			rocketbggy: 50
-			flamebggy: 50
+			smech: 50
+			riflebggy: 1
+			rocketbggy: 1
+			flamebggy: 10
 			trike: 50
-			struckfull: 70
-			centurion: 70
+			struckfull: 2
+			centurion: 40
 			scrdronec: 40
-			scrscorpion: 50
-			scrglyder2: 70
+			scrscorpion: 60
+			scrglyder2: 30
 			hvr: 90
-			ttnk: 90
+			ttnk: 20
 			subtank: 90
-			lynx: 80
-			mutquad: 90
-			wolf: 90
+			lynx: 50
+			mutquad: 30
+			wolf: 5
 			g4tnk: 90
-			scrmbt: 90
+			scrmbt: 1
 			sonic: 50
 			jug: 50
-			hmec: 50
-			mrls: 50
+			hmec: 30
+			mrls: 20
 			deathclaw: 50
 			spiderarty: 50
 			paladin: 50
 			tripod: 50
-			wasp: 30
-			basilisk: 30
-			devourer: 30
-			scrin: 30
-			cerberus: 30
-			orca: 30
+			wasp: 40
+			basilisk: 5
+			devourer: 5
+			scrin: 50
+			cerberus: 5
+			orca: 40
 			orcab: 30
-			mutheli: 30
-			wetp: 30
-			stormrider: 30
-			scrcarrier: 30
-			scrdestroyer: 30
-			scrbattleship: 30
+			mutheli: 40
+			wetp: 20
+			stormrider: 60
+			scrcarrier: 50
+			scrdestroyer: 10
+			scrbattleship: 50
+			howtlizer: 30
+			stnk: 40
+			apache: 5
+			nconf: 10
+			scrrecharger: 100
+			scrmobmine: 5
+			mutqueen: 1
+			lazorbggy : 15
+			moth: 2
+			nukecarryall_bot: 5
+			repairvehicle : 2
+			engineer: 1
+			e2: 1
+			swarmling: 1
+			shapeshifter: 1
 		UnitLimits:
-			harv: 5
-			scrharv: 5
-	McvManagerBotModule@test:
-		RequiresCondition: AIReload || AICheater
-		McvTypes: mcv, drache, cabmcv, nodmcv, mutmcv
+			harv: 4
+			scrharv: 4
+			scrrecharger: 1
+			scrmobmine: 2
+			mrls: 1
+			repairvehicle : 2
+			medic: 5
+			engineer: 1
+			e2: 1
+			swarmling: 1
+			shapeshifter: 1
+			scrdestroyer: 3
+			devourer: 5
+			nukecarryall_bot: 1
+		UnitDelays:
+			crusader: 3000
+			mutfiend: 3000
+			legio: 5000
+			cborg: 4000
+			rocketbggy: 3500
+	McvManagerBotModule@AIEasy:
+		RequiresCondition: AIEasy 
+		McvTypes: mcv, cabmcv, nodmcv, mutmcv, drache_bot, drache
 		ConstructionYardTypes: gacnst, mutyard, cabyard, nodyard, drached
-		McvFactoryTypes: gaweap, naweap, mutweap, cabweap, scrweap
+		McvFactoryTypes: gaweap, naweap, muweap, cabweap, scrair
+		MinimumConstructionYardCount: 1
+	McvManagerBotModule@AICheater:
+		RequiresCondition: AICheater
+		McvTypes: mcv, cabmcv, nodmcv, mutmcv, drache_bot, drache
+		ConstructionYardTypes: gacnst, mutyard, cabyard, nodyard, drached
+		McvFactoryTypes: gaweap, naweap, muweap, cabweap, scrair
+		MinimumConstructionYardCount: 2
+	McvManagerBotModule@ShatteredAI:
+		RequiresCondition: AIShattered
+		McvTypes: mcv, cabmcv, nodmcv, mutmcv, drache_bot, drache
+		ConstructionYardTypes: gacnst, mutyard, cabyard, nodyard, drached
+		McvFactoryTypes: gaweap, naweap, muweap, cabweap, scrair
+		MinimumConstructionYardCount: 5
 	SupportPowerBotModule:
-		RequiresCondition: AIReload || AICheater
+		RequiresCondition: AIReload
 		Decisions:
 			gdiradarscan:
 				OrderName: GDIRadarScan
@@ -294,7 +566,7 @@ Player:
 				MinimumAttractiveness: 3000
 				Consideration@1:
 					Against: Enemy
-					Types: Building
+					Types: Air, Ground, Water
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
@@ -312,8 +584,14 @@ Player:
 					Types: Building
 					Attractiveness: 1
 					TargetMetric: Value
-					CheckRadius: 5c0
+					CheckRadius: 6c0
 				Consideration@2:
+					Against: Enemy
+					Types: Air, Ground, Water
+					Attractiveness: 1
+					TargetMetric: Value
+					CheckRadius: 8c0
+				Consideration@3:
 					Against: Ally
 					Types: Air, Ground, Water
 					Attractiveness: -10
@@ -327,8 +605,14 @@ Player:
 					Types: Building
 					Attractiveness: 1
 					TargetMetric: Value
-					CheckRadius: 5c0
+					CheckRadius: 7c0
 				Consideration@2:
+					Against: Enemy
+					Types: Air, Ground, Water
+					Attractiveness: 1
+					TargetMetric: Value
+					CheckRadius: 7c0
+				Consideration@3:
 					Against: Ally
 					Types: Air, Ground, Water
 					Attractiveness: -10
@@ -342,8 +626,14 @@ Player:
 					Types: Building
 					Attractiveness: 1
 					TargetMetric: Value
-					CheckRadius: 5c0
+					CheckRadius: 6c0
 				Consideration@2:
+					Against: Enemy
+					Types: Ground, Water
+					Attractiveness: 1
+					TargetMetric: Value
+					CheckRadius: 5c0
+				Consideration@3:
 					Against: Ally
 					Types: Air, Ground, Water
 					Attractiveness: -10
@@ -354,7 +644,22 @@ Player:
 				MinimumAttractiveness: 3000
 				Consideration@1:
 					Against: Enemy
-					Types: Building
+					Types: Air, Ground, Water
+					Attractiveness: 1
+					TargetMetric: Value
+					CheckRadius: 6c0
+				Consideration@2:
+					Against: Ally
+					Types: Air, Ground, Water
+					Attractiveness: -10
+					TargetMetric: Value
+					CheckRadius: 7c0
+			toxinMissile:
+				OrderName: ToxinMissile
+				MinimumAttractiveness: 3000
+				Consideration@1:
+					Against: Enemy
+					Types: Ground, Water
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
@@ -364,3 +669,70 @@ Player:
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
+			droppod:
+				OrderName: Droppod
+				MinimumAttractiveness: 3000
+				Consideration@1:
+					Against: Enemy
+					Types: Ground
+					Attractiveness: 1
+					TargetMetric: Value
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Ally
+					Types: Infantry, Vehicle
+					Attractiveness: 1
+					TargetMetric: Value
+					CheckRadius: 5c0
+
+			nano:
+				OrderName: NanomachineSwarm
+				MinimumAttractiveness: 3000
+				Consideration@1:
+					Against: Ally
+					Types: Vehicle
+					Attractiveness: 2
+					TargetMetric: Value
+					CheckRadius: 7c0
+				Consideration@2:
+					Against: Ally
+					Types: Infantry
+					Attractiveness: 2
+					TargetMetric: Value
+					CheckRadius: 7c0
+			veinhole:
+				OrderName: Veinhole
+				MinimumAttractiveness: 3000
+				Consideration@1:
+					Against: Enemy
+					Types: Building
+					Attractiveness: 1000
+					TargetMetric: Value
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Ally
+					Types: Air, Ground, Water
+					Attractiveness: -10
+					TargetMetric: Value
+					CheckRadius: 7c0
+			chronoshiftsummon:
+				OrderName: ChronoshiftSummon
+				MinimumAttractiveness: 3000
+				Consideration@1:
+					Against: Enemy
+					Types: Infantry
+					Attractiveness: 3
+					TargetMetric: Value
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Enemy
+					Types: Vehicle
+					Attractiveness: 1
+					TargetMetric: Value
+					CheckRadius: 5c0
+	CaptureManagerBotModule:
+		CapturingActorTypes: engineer, e2, swarmling, shapeshifter
+		CapturableActorTypes: cahosp, neutralsonictur, caarmr, well, machineshop, scrinreinfpad
+		CheckCaptureTargetsForVisibility: false
+
+

--- a/mods/sp/rules/aircraft.yaml
+++ b/mods/sp/rules/aircraft.yaml
@@ -6,6 +6,7 @@ CLOUD1:
 	-UpdatesPlayerStatistics:
 	-ActorLostNotification:
 	-AppearsOnRadar:
+	-Repairable:
 	Aircraft:
 		CruiseAltitude: 1
 		TurnSpeed: 6
@@ -18,11 +19,11 @@ CLOUD1:
 	-RevealsShroud:
 	-Voiced:
 	Health:
-		HP: 9
+		HP: 650
 	SelfHealing:
-		Step: -1
-		Delay: 25
-		HealIfBelow: 200
+		Step: -600
+		Delay: 200
+		HealIfBelow: 5000
 		DamageTypes: CloudDie
 	AttackAircraft:
 		FacingTolerance: 20
@@ -78,7 +79,7 @@ ORCA:
 		MoveIntoShroud: true
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
+		InitialStanceAI: AttackAnything
 	Health:
 		HP: 12000
 	Armament:
@@ -137,7 +138,7 @@ ORCAB:
 		FacingTolerance: 20
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
+		InitialStanceAI: AttackAnything
 	AmmoPool:
 		Ammo: 20
 		PipCount: 2
@@ -195,7 +196,6 @@ DSHP:
 	Tooltip:
 		Name: Dropship
 	Aircraft:
-		LandWhenIdle: true
 		TurnSpeed: 10
 		Speed: 200
 		InitialFacing: 0
@@ -250,7 +250,6 @@ ORCATRAN:
 	RenderVoxels:
 	-WithFacingSpriteBody:
 	Aircraft:
-		LandWhenIdle: true
 		TurnSpeed: 5
 		Speed: 84
 		InitialFacing: 0
@@ -313,7 +312,7 @@ APACHE:
 		AmmoCondition: ammo
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
+		InitialStanceAI: AttackAnything
 	WithIdleOverlay@ROTORAIR:
 		Offset: 85,0,384
 		Sequence: rotor
@@ -373,7 +372,7 @@ SCRIN:
 		AmmoCondition: ammo
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
+		InitialStanceAI: AttackAnything
 	DeathSounds:
 	SpawnActorOnDeath:
 		Actor: SCRIN.Husk
@@ -492,7 +491,7 @@ MUTHELI:
 		AmmoCondition: ammo
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
+		InitialStanceAI: AttackAnything
 	SpawnActorOnDeath:
 		Actor: MUTHELI.Husk
 
@@ -540,7 +539,7 @@ WETP:
 	AutoTarget:
 		ScanRadius: 6
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
+		InitialStanceAI: AttackAnything
 	RenderSprites:
 	Hovers@CRUISING:
 		RequiresCondition: cruising
@@ -613,12 +612,59 @@ MUTQUEEN:
 	Explodes:
 		Weapon: QueenExplode
 		EmptyWeapon: QueenExplode
+	Explodes@AImicroManage:
+		RequiresCondition: AImicroManage
+		Weapon: SpawnEggShrapnelE
+		EmptyWeapon: SpawnEggShrapnelE
 
 MUTBIRD:
 	Inherits@3: MUTQUEEN
 	Tooltip:
 		Name: Seeder Bird
 	-Buildable:
+
+NUKECARRYALL_BOT:
+	Inherits: TRNSPORT
+	Inherits@1: ^AutoTargetAllAssaultMove
+	Buildable:
+		Description: AI Nuke Transport
+		Queue: Air
+		BuildPaletteOrder: 6
+		Prerequisites: ~muair, muhall, ~AImoney
+	Valued:
+		Cost: 1900
+	Health:
+		HP: 18000
+	GivesExperience:
+		Experience: 600
+	Cargo:
+		InitialUnits: hvrtruk3_bot
+	Armament@AIaiming:
+		RequireCondition: !unloading
+		Weapon: AITransportAimingDummyWeapon
+		LocalOffset: 950,0,0
+		ReloadingCondition: unloading
+	RejectsOrders@unloading:
+		Except: Unload
+		RequiresCondition: unloading
+	AttackAircraft:
+		AttackType: Hover
+		FacingTolerance: 128
+	AIDeployHelper:
+		DeployChance : 100
+		DeployTicks : 5
+		UndeployTicks : 30
+	AutoTarget:
+		ScanRadius: 9
+		InitialStanceAI: AttackAnything
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
+	TransformOnCondition:
+		RequiresCondition: !loaded
+		IntoActor: TRNSPORT
+	GrantConditionOnDamageState:
+		Condition: unloading
+		ValidDamageStates: Medium
 
 STORMRIDER:
 	Inherits: ^CombatPlane
@@ -673,7 +719,7 @@ DRACHE:
 		Queue: Air
 		BuildPaletteOrder: 110
 		Description: Deploys into a Host Station.\n\nSpecial:\n- Provides a build radius for structures\n- Maximum production speed is reached with 7 Conyards\n- Max production speed reduces production time by 50%\n- Has increased HP when deployed
-		Prerequisites: ~scrair
+		Prerequisites: ~scrair, ~!fixUndeployDracheBug
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -717,6 +763,18 @@ DRACHE:
 		Weapon: BigAircraftShrapnel
 		EmptyWeapon: BigAircraftShrapnel
 
+DRACHE_BOT:
+	Inherits: DRACHE
+	Buildable:
+		Queue: Air
+		BuildPaletteOrder: 110
+		Description: AI Scrin Host Station
+		Prerequisites: ~scrair, ~fixUndeployDracheBug
+	Aircraft:
+		IdleBehavior: Land
+	RenderSprites:
+		Image: drache
+
 SCRGLYDER1:
 	Inherits: ^CombatHelicopter
 	Inherits@1: ^AutoTargetAllAssaultMove
@@ -758,6 +816,14 @@ SCRGLYDER1:
 	SmokeParticleEmitter:
 		Image: scrsmoke
 		Palette: apolbluealpha60
+	Armament@AIaimOnly:
+		Weapon: AIGlyder1AimingDummyWeapon
+		RequiresCondition: AImicroManage
+		PauseOnCondition: empdisable
+		ReloadingCondition: AIattackGround
+	TransformOnCondition:
+		RequiresCondition: AIattackGround
+		IntoActor: scrglyder2
 
 SCRDESTROYER:
 	Inherits: ^CombatHelicopter

--- a/mods/sp/rules/defaults.yaml
+++ b/mods/sp/rules/defaults.yaml
@@ -868,36 +868,38 @@
 		Ammo: 8
 	ReloadAmmoPool@AIReload:
 		AmmoPool: primary
-		RequiresCondition: AIReload || AICheater
-		Count: 1
-		Delay: 150
+		RequiresCondition: AIReload
+		Count: 10
+		Delay: 1500
 	GrantConditionOnBotOwner@AIReload:
 		Condition: AIReload
-		Bots: CheaterAI, EasyAI
-	GrantConditionOnBotOwner@AICheater:
-		Condition: AICheater
-		Bots: CheaterAI
+		Bots: CheaterAI, EasyAI, ShatteredAI
 
 ^AIBuffCheat:
 	GrantConditionOnBotOwner@AIBuffCheat:
 		Condition: AIBuffCheat
-		Bots: CheaterAI
+		Bots: CheaterAI, ShatteredAI
 	FirepowerMultiplier@AIBuffCheat:
 		RequiresCondition: AIBuffCheat
-		Modifier: 120
+		Modifier: 110
 	DamageMultiplier@AIBuffCheat:
 		RequiresCondition: AIBuffCheat
-		Modifier: 80
+		Modifier: 90
 
 ^AICashCheat:
+	CashTrickler@AICashDevour:
+		Interval: 1100
+		Amount: 800
+		ShowTicks: False
+		RequiresCondition: AIShattered
 	CashTrickler@AICashCheater:
 		Interval: 1000
-		Amount: 600
+		Amount: 350
 		ShowTicks: False
 		RequiresCondition: AICheater
 	CashTrickler@AICashNormal:
 		Interval: 600
-		Amount: 200
+		Amount: 50
 		ShowTicks: False
 		RequiresCondition: AIReload || AICheater
 	GrantConditionOnBotOwner@AIReload:
@@ -906,7 +908,23 @@
 	GrantConditionOnBotOwner@AICheater:
 		Condition: AICheater
 		Bots: CheaterAI
-
+	GrantConditionOnBotOwner@AIShattered:
+		Condition: AIShattered
+		Bots: ShatteredAI
+^AImicroManagable:
+	GrantConditionOnBotOwner@AImicroManage:
+		Condition: AImicroManage
+		Bots: EasyAI, CheaterAI, ShatteredAI
+^AIbuildingMicroControl:
+	GrantConditionOnBotOwner@AIbuildingMicroControl:
+		Condition: AIbuildingMicroControl
+		Bots: CheaterAI, EasyAI, ShatteredAI
+	ProvidesPrerequisite@AISpecialProduce:
+		RequiresCondition: AIbuildingMicroControl
+		Prerequisite: AImoney
+	ProvidesPrerequisite@fixUndeployDracheBug:
+		RequiresCondition: AIbuildingMicroControl
+		Prerequisite: fixUndeployDracheBug
 ^GenericEffects:
 	Inherits@0: ^KillSelf
 	Inherits@1: ^Cloakable
@@ -972,6 +990,7 @@
 	Inherits@2: ^SpawnSmoke
 	Inherits@3: ^SpawnSpark
 	Inherits@4: ^GetsOneShotedbySuperweapons
+	Inherits@5: ^MindControllable
 
 ^ProducesStuff:
 	WithTextDecoration@primary:
@@ -1070,6 +1089,7 @@
 	Inherits@0: ^BasicBuilding
 	Inherits@1: ^StructureEffects
 	Inherits@2: ^4CellVision
+	Inherits@AIbuilding: ^AIbuildingMicroControl
 	GivesBuildableArea:
 		AreaTypes: building
 	CaptureNotification:
@@ -1287,6 +1307,7 @@
 	Inherits@4: ^InfantryShape
 	Inherits@5: ^5CellVision
 	Inherits@SELECTION_MODE: ^FlatSelectionMode
+	Inherits@AImicroManagable: ^AImicroManagable
 	ActorLostNotification:
 	SharedPassenger:
 		CargoType: Infantry
@@ -1681,6 +1702,7 @@
 	Inherits@3: ^VehicleShape
 	Inherits@4: ^5CellVision
 	Inherits@SELECTION_MODE: ^FlatSelectionMode
+	Inherits@AImicroManagable: ^AImicroManagable
 	ActorLostNotification:
 	Huntable:
 	SharedPassenger:
@@ -1833,6 +1855,7 @@
 ^ScrinVehicle:
 	Inherits@0: ^ScrinReaper
 	Inherits@1: ^ScrinRender
+	Inherits@AImicroManagable: ^AImicroManagable
 	Explodes:
 		Weapon: ScrinUnitExplode
 		EmptyWeapon: ScrinUnitExplode
@@ -1916,15 +1939,16 @@
 	Inherits@6: ^Cloakable
 	Inherits@5: ^FullHealthRepairCondition
 	Inherits@SELECTION_MODE: ^FlatSelectionMode
+	Inherits@AImicroManagable: ^AImicroManagable
 	DrawLineToTarget:
 	WithTextControlGroupDecoration:
 	AppearsOnRadar:
 		UseLocation: true
 	Targetable@GROUND:
-		TargetTypes: Vehicle, Ground, LandedAircraft
+		TargetTypes: Vehicle, Ground, LandedAircraft, MindControlInmune
 		RequiresCondition: !airborne
 	Targetable@AIRBORNE:
-		TargetTypes: Air
+		TargetTypes: Air, MindControlInmune
 		RequiresCondition: airborne
 	Selectable:
 	SelectionDecorations:

--- a/mods/sp/rules/infantry.yaml
+++ b/mods/sp/rules/infantry.yaml
@@ -127,6 +127,7 @@ JUMPJET:
 		HP: 9000
 	Transforms:
 		IntoActor: jumpjetair
+		RequiresCondition: !inside-tunnel
 	Armament@1:
 		Weapon: JJGroundGrenade
 		PauseOnCondition: WebDisable
@@ -439,6 +440,10 @@ NCONF:
 	ExplodeWeapon@3:
 		Weapon: TickHoloShrapnel
 		RequiresCondition: HologramSpawn
+	AIDeployHelper:
+		DeployChance : 100
+		DeployTicks : 4000
+		UndeployTicks : 1
 
 BHS:
 	Inherits: ^Soldier
@@ -538,7 +543,7 @@ MARAUDER:
 		ScanRadius: 8
 	Mobile:
 		PauseOnCondition: WebDisable
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !AImicroManage && !undeployed
 	Passenger:
 		RequireForceMoveCondition: !undeployed
 	Armament@1:
@@ -566,6 +571,7 @@ MARAUDER:
 		UndeploySounds:
 		UndeployOnMove: true
 		RequiresCondition: !inside-tunnel
+		PauseOnCondition: deployed && AImicroManage
 	GrantCondition:
 		Condition: editorhack
 	WithInfantryBody@Editor: # HACK: negative conditions don't count in EnabledByDefault, we can use this duplicate WIB to render it on map editor
@@ -611,9 +617,16 @@ MARAUDER:
 	DamageMultiplier@MarauderBuff:
 		Modifier: 75
 		RequiresCondition: deployed
+	AIDeployHelper:
+		DeployChance: 100
+		DeployTrigger: Attack
+		DeployTicks : 0
 	RejectsOrders@deployment:
 		Reject: AttackMove, AssaultMove
-		RequiresCondition: deployed
+		RequiresCondition: !AImicroManage && deployed
+	RejectsOrders@deploymentAI:
+		Reject: GrantConditionOnDeploy
+		RequiresCondition: AImicroManage && deployed
 
 MUTFIEND:
 	Inherits: ^Mutant
@@ -798,6 +811,11 @@ SEER:
 	ExplodeWeapon@2:
 		Weapon: SeerTyranyInstakillSpawn
 		RequiresCondition: deployed
+	AIDeployHelper:
+		DeployChance : 50
+		DeployTicks : 2000
+		UndeployTicks : 1
+		DeployTrigger : Attack
 
 PSYKER:
 	Inherits: ^Mutant
@@ -1163,6 +1181,31 @@ COLOSSI:
 	RejectsOrders@deployment:
 		Reject: AttackMove, AssaultMove
 		RequiresCondition: deployed
+ 
+COLOSSI_CHRONO:
+	Inherits: COLOSSI
+	-Buildable:
+	Mobile:
+		RequireForceMoveCondition: !AImicroManage && !undeployed
+	Armament@1:
+		Weapon: SharkJump
+		PauseOnCondition: WebDisable
+	Armament@2:
+		Weapon: SharkJump
+		PauseOnCondition: WebDisable
+	AIDeployHelper:
+		DeployChance : 100
+		DeployTicks : 0
+		UndeployTicks : 250
+		DeployTrigger : Attack
+	RenderSprites:
+		Image: colossi
+	RejectsOrders@deployment:
+		Reject: AttackMove, AssaultMove
+		RequiresCondition: !AImicroManage && deployed
+	RejectsOrders@deploymentAI:
+		Reject: GrantConditionOnDeploy
+		RequiresCondition: AImicroManage && deployed
 
 CABSENTRY:
 	Inherits: ^CabalDroneInfantry
@@ -1479,7 +1522,7 @@ MOTH:
 		Speed: 100
 		Locomotor: HoverInfantry
 		PauseOnCondition: WebDisable
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !AImicroManage && !undeployed
 	Passenger:
 		RequireForceMoveCondition: !undeployed
 	LeavesTrails:
@@ -1511,9 +1554,13 @@ MOTH:
 		UndeployOnMove: true
 		CanDeployOnRamps: true
 		RequiresCondition: !inside-tunnel
+		PauseOnCondition: deployed && AImicroManage
 	RejectsOrders@deployment:
 		Reject: AttackMove, AssaultMove
-		RequiresCondition: deployed
+		RequiresCondition: !AImicroManage && deployed
+	RejectsOrders@deploymentAI:
+		Reject: GrantConditionOnDeploy
+		RequiresCondition: AImicroManage && deployed
 	Cloak@cloakgenerator:
 		RequiresCondition: deployed
 		InitialDelay: 40
@@ -1541,12 +1588,20 @@ MOTH:
 		RequiresCondition: deployed
 		PauseOnCondition: WebDisable
 	AttackOmni:
-		RequiresCondition: deployed
+		RequiresCondition: AImicroManage || deployed
 		PauseOnCondition: WebDisable
 		Armaments: OnFoot
+	Armament@AIAimOnly
+		RequiresCondition: AImicroManage && !deployed
+		Weapon: LurkerAim
+		Name: OnFoot
+		PauseOnCondition: WebDisable
 	RenderRangeCircle:
 	-WithIdleOverlay@web:
 	-Crushable:
+	AIDeployHelper:
+		DeployChance : 100
+		DeployTicks : 0
 
 CYC2:
 	Inherits: ^Cyborg

--- a/mods/sp/rules/sharedrules.yaml
+++ b/mods/sp/rules/sharedrules.yaml
@@ -386,7 +386,12 @@ GACNST:
 	SelectionDecorations:
 	RequiresBuildableArea:
 		AreaTypes: building
-
+	ProvidesPrerequisite@AIantiRush:
+		RequiresCondition: !AIbuildingMicroControl
+		Prerequisite: AIantiRush
+	Power@AICheatPower:
+		RequiresCondition: AIShattered
+		Amount: 80
 ^Powerplant:
 	Inherits: ^Building
 	ProvidesPrerequisite:
@@ -429,6 +434,8 @@ GACNST:
 	ProvidesPrerequisite@buildingname:
 	GrantExternalConditionToProduced:
 		Condition: produced
+	ProvidesPrerequisite@AIantiRush:
+		Prerequisite: AIantiRush
 
 ^RefineryHP:
 	Health:
@@ -457,6 +464,7 @@ PROC:
 	Inherits: ^Building
 	Inherits@1: ^NormalRefineryHitShape
 	Inherits@2: ^RefineryHP
+	Inherits@3: ^AICashCheat
 	Building:
 		Footprint: xx== xx== xx==
 		Dimensions: 4,3
@@ -491,7 +499,8 @@ PROC:
 FLIPPEDPROC:
 	Inherits: ^Building
 	Inherits@1: ^FlippedRefineryHitshape
-	Inherits@2: ^RefineryHP
+	Inherits@2: ^RefineryHP	 
+	Inherits@3: ^AICashCheat
 	ProvidesPrerequisite:
 		Factions: gdi, cab, mut, nod, scr
 		Prerequisite: proc
@@ -529,6 +538,7 @@ FLIPPEDXPROC:
 	Inherits: ^Building
 	Inherits@1: ^FlippedRefineryXHitshape
 	Inherits@2: ^RefineryHP
+	Inherits@3: ^AICashCheat
 	ProvidesPrerequisite:
 		Factions: gdi, cab, mut, nod, scr
 		Prerequisite: proc
@@ -566,6 +576,7 @@ FLIPPEDYPROC:
 	Inherits: ^Building
 	Inherits@1: ^FlippedRefineryYHitshape
 	Inherits@2: ^RefineryHP
+	Inherits@3: ^AICashCheat
 	ProvidesPrerequisite:
 		Factions: gdi, cab, mut, nod, scr
 		Prerequisite: proc
@@ -656,6 +667,8 @@ FLIPPEDYPROC:
 		ValidStances: Enemy, Neutral
 	GrantExternalConditionToProduced:
 		Condition: produced
+	ProvidesPrerequisite@AIantiRush:
+		Prerequisite: AIantiRush
 
 ^Helipad:
 	Inherits: ^Building
@@ -689,6 +702,8 @@ FLIPPEDYPROC:
 		Amount: -20
 	WithSpriteBody:
 		PauseOnCondition: disabled
+	ProvidesPrerequisite@AIantiRush:
+		Prerequisite: AIantiRush
 
 ^Radar:
 	Inherits: ^Building

--- a/mods/sp/rules/structures.yaml
+++ b/mods/sp/rules/structures.yaml
@@ -113,7 +113,7 @@ GDIREF:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 3
-		Prerequisites: ~structures.gdi, anypower
+		Prerequisites: ~structures.gdi, anypower, ~AIantiRush
 		Description: Processes raw Tiberium into useable resources.\nCan be rotated.\n\nSpecial:\n- Stores 1000$.
 	FreeActor:
 		Actor: harv.gdi
@@ -443,7 +443,7 @@ NODREF:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 3
-		Prerequisites: ~structures.nod, anypower
+		Prerequisites: ~structures.nod, anypower, ~AIantiRush
 		Description: Processes raw Tiberium into useable resources.\nCan be rotated.\n\nSpecial:\n- Stores 1000$.
 	FreeActor:
 		Actor: harv.nod
@@ -809,7 +809,7 @@ MUPROC:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 3
-		Prerequisites: ~structures.mut, anypower
+		Prerequisites: ~structures.mut, anypower, ~AIantiRush
 		IconPalette: UnittemIconMut
 		Description: Processes raw Tiberium into useable resources.\nCan be rotated.\n\nSpecial:\n- Stores 1000$.
 	FreeActor:
@@ -1114,7 +1114,7 @@ SCRPROC:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 3
-		Prerequisites: scrpowr, ~structures.scr
+		Prerequisites: scrpowr, ~structures.scr, ~AIantiRush
 		Description: Processes raw Tiberium into useable resources.\nCan be rotated.\n\nSpecial:\n- Stores 4000$.
 		IconPalette: UnittemIconScrin
 	Selectable:
@@ -1326,6 +1326,7 @@ SCRADVPOWR:
 		DecorationBounds: 90, 84, 0, -12
 	SelectionDecorations:
 	ChronoshiftPower@chronoshift:
+		RequiresCondition: !AIbuildingMicroControl
 		Range: 2
 		OrderName: Chronoshift
 		PauseOnCondition: empdisable || disabled
@@ -1350,6 +1351,26 @@ SCRADVPOWR:
 		InvalidTileSequence: build-invalid-
 		SourceTileSequence: build-valid-
 		DisplayTimerStances: Ally, Neutral, Enemy
+	DetonateWeaponPower@AIbuilding:
+		RequiresCondition: AIbuildingMicroControl
+		Weapon: ColossiSummonerWeapon
+		Icon: wormholeicon
+		IconPalette: playerscrin
+		ChargeInterval: 6000
+		OrderName: ChronoshiftSummon
+		TargetCircleRange: 5c0
+		DisplayTimer: True
+		DisplayBeacon: True
+		EndChargeSound: SuperWeaponReady
+		EndChargeSpeechNotification: SuperWeaponReady
+		LaunchSpeechNotification: SuperweaponFired
+		IncomingSpeechNotification: SuperweaponFired
+		IncomingSound: SuperweaponFired
+		LaunchSound: n_swlaunch.aud
+		Description: Instant Wormhole
+		LongDesc: Instant Wormhole for AI
+		DisplayTimerStances: Ally, Neutral, Enemy
+		PauseOnCondition: empdisable || disabled
 	Health:
 		HP: 300000
 	RequiresBuildableArea:
@@ -1486,7 +1507,7 @@ CABPROC:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 3
-		Prerequisites: anypower, ~structures.cab
+		Prerequisites: anypower, ~structures.cab, ~AIantiRush
 		Description: Processes raw Tiberium into useable resources.\nCan be rotated.\n\nSpecial:\n- Stores 1000$.
 		IconPalette: UnittemIconCab
 	FreeActor:

--- a/mods/sp/rules/support.yaml
+++ b/mods/sp/rules/support.yaml
@@ -337,13 +337,16 @@ MUBUNKRFULL:
 	Buildable:
 		Prerequisites: murax, ~structures.mut, ~AImoney
 	Valued:
-		Cost: 1000
+		Cost: 1050
+	GivesExperience:
+		Experience: 500
 	RenderSprites:
 		Image: mubunkr
 	EditorOnlyTooltip:
 		Name: Filled Bunker
 	Cargo:
-		InitialUnits: marauder, marauder, mutfiend, mutfiend
+		EjectOnDeath: True
+		InitialUnits: marauder, marauder, mutfiend, marauder, marauder
 
 MUCANNON:
 	Inherits: ^Defence

--- a/mods/sp/rules/vehicles.yaml
+++ b/mods/sp/rules/vehicles.yaml
@@ -769,11 +769,28 @@ BGGY:
 	Tooltip@float:
 		Name: Essential Buggy
 		RequiresCondition: ifv.float
+RIFLEBGGY:
+	Inherits: BGGY
+	Valued:
+		Cost: 400
+	GivesExperience:
+		Experience: 300
+	EditorOnlyTooltip:
+		Name: Anti Infantry Buggy
+	RenderSprites:
+		Image: bggy
+	Buildable:
+		Prerequisites: ~naweap, ~AImoney
+	Cargo:
+		EjectOnDeath: True
+		InitialUnits: altnode1
 
 ROCKETBGGY:
 	Inherits: BGGY
 	Valued:
 		Cost: 600
+	GivesExperience:
+		Experience: 300
 	EditorOnlyTooltip:
 		Name: Rocket Buggy
 	RenderSprites:
@@ -781,20 +798,40 @@ ROCKETBGGY:
 	Buildable:
 		Prerequisites: ~naweap, ~AImoney
 	Cargo:
+		EjectOnDeath: True
 		InitialUnits: crusader
 
 FLAMEBGGY:
 	Inherits: BGGY
 	Valued:
 		Cost: 600
+	GivesExperience:
+		Experience: 300
 	RenderSprites:
 		Image: bggy
 	Buildable:
 		Prerequisites: ~naweap, naradr, ~AImoney
 	Cargo:
+		EjectOnDeath: True
 		InitialUnits: templar
 	EditorOnlyTooltip:
 		Name: Flame Buggy
+
+LAZORBGGY:
+	Inherits: BGGY
+	Valued:
+		Cost: 900
+	GivesExperience:
+		Experience: 300
+	RenderSprites:
+		Image: bggy
+	Buildable:
+		Prerequisites: ~naweap, natech, ~AImoney
+	Cargo:
+		EjectOnDeath: True
+		InitialUnits: nconf
+	EditorOnlyTooltip:
+		Name: Laser Buggy
 
 TTNK:
 	Inherits: ^Tank
@@ -817,7 +854,7 @@ TTNK:
 		Speed: 90
 		Locomotor: InfantryCrusherVehicle
 		PauseOnCondition: empdisable
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition:  !AImicroManage && !undeployed
 	Passenger:
 		RequireForceMoveCondition: !undeployed
 	Health:
@@ -853,11 +890,14 @@ TTNK:
 		CanDeployOnRamps: True
 		UndeployOnMove: true
 		UndeploySounds: clicky1.aud
-		PauseOnCondition: RefineryLock
+		PauseOnCondition: RefineryLock || (deployed && AImicroManage)
 		RequiresCondition: !inside-tunnel
 	RejectsOrders@deployment:
 		Reject: AttackMove, AssaultMove
-		RequiresCondition: deployed
+		RequiresCondition: !AImicroManage && deployed
+	RejectsOrders@deploymentAI:
+		Reject: GrantConditionOnDeploy
+		RequiresCondition: AImicroManage && deployed
 	Carryable:
 		RequiresCondition: undeployed
 	WithFacingSpriteBody:
@@ -890,6 +930,10 @@ TTNK:
 		Condition: undeployed
 	ExternalCondition@RefineryLock:
 		Condition: RefineryLock
+	AIDeployHelper:
+		DeployChance: 100
+		DeployTrigger: Attack
+		DeployTicks : 0
 
 TICKHOLOGRAM:
 	Inherits: TTNK
@@ -1365,8 +1409,11 @@ STRUCKFULL:
 	Buildable:
 		Prerequisites: ~muweap, murax, ~AImoney
 	Valued:
-		Cost: 1200
+		Cost: 1400
+	GivesExperience:
+		Experience: 500
 	Cargo:
+		EjectOnDeath: True
 		InitialUnits: marauder, marauder, mutfiend, mutfiend, e3
 	RenderSprites:
 		Image: struck
@@ -1545,6 +1592,19 @@ HVRTRUK3:
 	AutoTarget:
 	AttackFrontal:
 
+HVRTRUK3_BOT:
+	Inherits: HVRTRUK3
+	Inherits@1: ^AutoTargetGroundAssaultMove
+	-Buildable:
+	AutoTarget:
+		ScanRadius: 8
+		InitialStance: AttackAnything
+		InitialStanceAI: AttackAnything
+	AttackFrontal:
+		TargetFrozenActors: True
+	RenderSprites:
+		Image: HVRTRUK3
+
 ###########################################################
 # SCRIN
 ###########################################################
@@ -1642,6 +1702,7 @@ SCRGLYDER2:
 		Speed: 90
 		Locomotor: Hover
 	Transforms:
+		RequiresCondition: !inside-tunnel
 		IntoActor: scrglyder1
 	Armament:
 		Weapon: Glyder2Cannon
@@ -1652,6 +1713,17 @@ SCRGLYDER2:
 	AttackFrontal:
 		PauseOnCondition: empdisable
 		FacingTolerance: 5
+	Armament@AIaimOnly:
+		RequiresCondition: AImicroManage
+		Weapon: AIGlyder2AimingDummyWeapon
+		Recoil: 85
+		RecoilRecovery: 25
+		LocalOffset: 100,0,1500
+		PauseOnCondition: empdisable
+		ReloadingCondition: AIattackAir
+	TransformOnCondition:
+		RequiresCondition: AIattackAir && !inside-tunnel
+		IntoActor: scrglyder1
 
 SCRRECHARGER:
 	Inherits@1: ^Walker

--- a/mods/sp/sequences/gdiseq.yaml
+++ b/mods/sp/sequences/gdiseq.yaml
@@ -1386,77 +1386,77 @@ ionbeammini:
 	defaults:
 		UseTilesetCode: false
 	idle:
-		Offset: 0,-30, 1024
+		Offset: 0,-30
 		Length: *
 	stand:
-		Offset: 0,-60, 1024
+		Offset: 0,-60
 		Length: *
 	beamsky:
-		Offset: 0,-90, 1024
+		Offset: 0,-90
 		Length: *
 	beamsky2:
-		Offset: 0,-120, 1024
+		Offset: 0,-120
 		Length: *
 	beamsky3:
-		Offset: 0,-150, 1024
+		Offset: 0,-150
 		Length: *
 	beamsky4:
-		Offset: 0,-180, 1024
+		Offset: 0,-180
 		Length: *
 	beamsky5:
-		Offset: 0,-240, 1024
+		Offset: 0,-240
 		Length: *
 	beamsky6:
-		Offset: 0,-270, 1024
+		Offset: 0,-270
 		Length: *
 	beamsky7:
-		Offset: 0,-300, 1024
+		Offset: 0,-300
 		Length: *
 	beamsky8:
-		Offset: 0,-330, 1024
+		Offset: 0,-330
 		Length: *
 	beamsky9:
-		Offset: 0,-360, 1024
+		Offset: 0,-360
 		Length: *
 	beamsky10:
-		Offset: 0,-390, 1024
+		Offset: 0,-390
 		Length: *
 	beamsky11:
-		Offset: 0,-420, 1024
+		Offset: 0,-420
 		Length: *
 	beamsky12:
-		Offset: 0,-450, 1024
+		Offset: 0,-450
 		Length: *
 	beamsky13:
-		Offset: 0,-480, 1024
+		Offset: 0,-480
 		Length: *
 	beamsky14:
-		Offset: 0,-510, 1024
+		Offset: 0,-510
 		Length: *
 	beamsky15:
-		Offset: 0,-540, 1024
+		Offset: 0,-540
 		Length: *
 	beamsky16:
-		Offset: 0,-570, 1024
+		Offset: 0,-570
 		Length: *
 	beamsky17:
-		Offset: 0,-600, 1024
+		Offset: 0,-600
 		Length: *
 	beamsky18:
-		Offset: 0,-630, 1024
+		Offset: 0,-630
 		Length: *
 	beamsky19:
-		Offset: 0,-660, 1024
+		Offset: 0,-660
 		Length: *
 	beamsky20:
-		Offset: 0,-690, 1024
+		Offset: 0,-690
 		Length: *
 	muzzle: ringmini
-		Offset: 0,-6, 1024
+		Offset: 0,-6
 		Length: *
 		Tick: 5
 	muzzle2: ringmini
-		Offset: 0,-6, 1024
+		Offset: 0,-6
 		Length: *
 		Tick: 10
 	scorch:

--- a/mods/sp/sequences/mutseq.yaml
+++ b/mods/sp/sequences/mutseq.yaml
@@ -475,6 +475,10 @@ wolf:
 		Start: 381
 		Length: 9
 		ShadowStart: 771
+	die-crushed:
+		Start: 354
+		Length: 10
+		ShadowStart: 744
 	icon: wolficon
 
 deathclaw:

--- a/mods/sp/weapons/cabweapons.yaml
+++ b/mods/sp/weapons/cabweapons.yaml
@@ -137,6 +137,14 @@ GLAD120mm:
 		Versus:
 			BuildingArmor: 75
 
+LurkerAim:
+	Inherits: ^RifleWarhead
+	ReloadDelay: 40
+	Range: 10c0
+	Warhead@1Dam: SpreadDamage
+		Damage: 0
+		ValidTargets: Infantry, Vehicle, Building
+
 LurkerProj:
 	Inherits: ^FullDamage
 	ReloadDelay: 100

--- a/mods/sp/weapons/mutweapons.yaml
+++ b/mods/sp/weapons/mutweapons.yaml
@@ -511,6 +511,17 @@ SpawnEggShrapnel:
 		ValidStances: Enemy
 		ValidTargets: Infantry, Building, Vehicle, Defence, Air, Airhit
 
+ 
+SpawnEggShrapnelE:
+	Inherits: SpawnEggShrapnel
+	Warhead@op2: FireShrapnel
+		Weapon: EggElevator
+		Amount: 2
+		AimChance: 100
+		AllowDirectHit: true
+		ValidStances: Enemy
+		ValidTargets: Infantry, Building, Vehicle, Defence, Air, Airhit
+
 EggElevator:
 	Inherits: ^NoDamage
 	ReloadDelay: 5
@@ -699,3 +710,20 @@ VeinholeEggElevator:
 	Inherits: EggElevator
 	MinRange: 1c0
 	ReloadDelay: 800
+
+AITransportAimingDummyWeapon:
+	Inherits: ^FullDamage
+	ReloadDelay: 400
+	MinRange: 2c0
+	Range: 4c0
+	ValidTargets: Ground, Water
+	Projectile: InstantHit
+	Warhead@1Dam: SpreadDamage
+		Damage: 0
+		Versus:
+			InfantryArmor: 150
+			BuildingArmor: 80
+			VehicleArmor: 80
+			DefenseArmor: 80
+			ConcreteArmor: 30
+		ValidTargets: Ground, Water

--- a/mods/sp/weapons/scrweapons.yaml
+++ b/mods/sp/weapons/scrweapons.yaml
@@ -472,6 +472,30 @@ Glyder2Cannon:
 		ValidTargets: Air
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 
+AIGlyder1AimingDummyWeapon:
+	Inherits: ^NoDamage
+	ReloadDelay: 50
+	Range: 6c0
+	Burst: 1
+	MinRange: 0c100
+	ValidTargets: Air
+	Warhead@1Dam: SpreadDamage
+		Spread: 0
+		Damage: 0
+		ValidTargets: Air
+
+AIGlyder2AimingDummyWeapon:
+	Inherits: ^NoDamage
+	ReloadDelay: 50
+	Range: 6c0
+	MinRange: 0c100
+	Burst: 1
+	ValidTargets: Ground, Water
+	Warhead@1Dam: SpreadDamage
+		Spread: 0
+		Damage: 0
+		ValidTargets: Ground, Water
+
 BattleshipCannon:
 	Inherits: ^FullDamage
 	Inherits@2: ^Scrin_Explo

--- a/mods/sp/weapons/superweapons.yaml
+++ b/mods/sp/weapons/superweapons.yaml
@@ -826,3 +826,42 @@ VeinholeShrapnel:
 		Actors: veinholespawnerdummy
 		FallRate: 5000
 		Range: 3
+
+ColossiSummonerWeapon:
+	Inherits: ^BombWarhead
+	ReloadDelay: 8
+	Range: 3c0
+	ValidTargets: Ground, Water, BlueTiberium, Tiberium, Air, Vehicle, Building, Infantry, Water
+	Warhead@1Dam: SpreadDamage
+		Spread: 650
+		Damage: 0
+		Falloff: 1000, 500, 250, 125, 75, 50, 25, 12, 0
+		ValidTargets: Ground, Water, BlueTiberium, Tiberium, Air, Vehicle, Building, Infantry, Water
+		DamageTypes:
+	Warhead@5Actor: SpawnActor
+		Actors: colossi_chrono
+		FallRate: 5000
+		ForceGround: true
+		Range: 3
+	Warhead@4Sharpnel: FireShrapnel
+		Weapon: ColossiShrapnel
+		Amount: 3
+		AllowDirectHit: false
+		ValidTargets: Ground, Water, BlueTiberium, Tiberium, Air, AirHit
+		InvalidTargets: Infantry, Vehicle, Building, Wall
+	Warhead@5Sound: CreateEffect
+		ImpactSounds: instantrift.wav
+
+ColossiShrapnel:
+	Range: 3c0
+	MinRange: 1c0
+	Projectile: InstantHit
+	Warhead@1Dam: SpreadDamage
+		Spread: 1
+		Damage: 0
+		DamageTypes: Prone100Percent, TriggerProne, FireDeath
+	Warhead@5Actor: SpawnActor
+		Actors: colossi_chrono
+		ForceGround: true
+		FallRate: 5000
+		Range: 3


### PR DESCRIPTION
Fix #31
Fix #21
and more

     1.   Bug fix:
            1.1 The toxic gas belongs to AI will never disappear bug. Because “cloud1” is a “aircraft” so it is effected by buff cheating (damage reduce). It also can’t repair for now.
            1.2 Deploy order can't be delivered in tunnel for jumjet and glider now.
            1.3 Fix the iron cannon minibeam image disapear at some graphic resolution settings in some of my own bug report here.
            1.4 Fix crash bug when Bull crushed by MKII.
            1.5 Fix crash bug when aircraft being mindcontrol.

      2.   AI Fixing:
            2.1 Remake of AI.yaml and complish it. Units, SW, building, etc. Enable “AImoney”(pre-load) units of your orignal design.
            2.2 Make All AI always build barrack first to make player harder to rush at beginning.
            2.3 Make Queen trigger their skill when dead when they controlled by AI. Imitating AI is using it. Default AI deploy helper is not very good at this so I keep my orignal AI design.
            2.4 Make (nod, mutant) AI ground transport always have their passenger survive when explodes. Imitating AI is micromanaging.
            2.5 Make Scrin AI's Glider transform when attack ground/air units
            2.6 Make AI can use unit that needs deploying and adjust to perfect state. Ttank, blackhand, moth, etc.
            2.7 Scrin AI doesn't deploy MCV if it is not landing. So I make a fake unit for AI to build.
            2.8 Mutant AI doesn't build MCV -- fixed
            2.9 Scrin AI has a new support power for its secondary SW instead of teleport, but imitating teleport.
            2.10     Mutant AI will use carryall-demotruck combo (pre-load unit)
            2.11     AI Engineers will now capture tech-buildings.
            2.12     AI now has a dangerous new brain on using each SW according to their feature.
            2.13     make AI airforce more offensive instead of return fire stance at defualt.
            2.14     Fix the AI catch up tech too quickly and forget powerplant. Add a delay timer for tech building (and some defences) accroding to each faction’s powerplant. 
            2.15     Accroding to the suggestion and testing of @HansNilhall, make a new AI -- Shattered AI for utimate challenge for players, and make AI like:
                 (1) EasyAI now is a simple AI but with AI micro-manage. Inviting new players and intruduce the units more detaily in combat.
                 (2) CheaterAI now is harder, forcing the players learns the needs of have more than one minefield in PVP. Addtional MCV make players have to not turtle by only use SW.
                 (3) New Shattered AI is hardest and forcing the players try control as much as the resource point, and dealing with endless foes with full power and production lines.
