### PR TITLE
Fix wormhole generator prerequisite bug

### DIFF
--- a/mods/sp/rules/structures.yaml
+++ b/mods/sp/rules/structures.yaml
@@ -1314,7 +1314,7 @@ SCRADVPOWR:
 	Valued:
 		Cost: 1500
 	ProvidesPrerequisite:
-		Prerequisite: scrpowr
+		Prerequisite: scradvpowr
 	Building:
 		Footprint: xxx xxx xxx
 		Dimensions: 3,3


### PR DESCRIPTION
Fix a bug that wormhole generator has a powerplant prerequisite but don't have it own prerequisite .

bug: when there is wormhole generator and scr-conyard, you can skip scr-powerplant as prerequisite and build barrack and refinary.

add: It is very lucky here before fix becuase this bug should have caused the battleship was not able to built, but the "techtree.cs" of OpenRA which consider the buildlimit as a "prerequisite" to simplify the buidable check, in which it considers the actor's info name as "prerequisite" (and counting how many actors) and it can conflict with normal prerequisite has the same string, which make it looks like a build limit actor always provides a "prerequisite" of its own name. 