### PR TITLE
Bug fix 3 - AI refactor and remake Easy AI

### DIFF
--- a/mods/sp/rules/ai.yaml
+++ b/mods/sp/rules/ai.yaml
@@ -8,8 +8,8 @@ Player:
 	ModularBot@ShatteredAI:
 		Name: Shattered AI
 		Type: ShatteredAI
-	GrantConditionOnBotOwner@AIReload:
-		Condition: AIReload
+	GrantConditionOnBotOwner@AIBase:
+		Condition: AIBase
 		Bots: CheaterAI, EasyAI, ShatteredAI
 	GrantConditionOnBotOwner@AIEasy:
 		Condition: AIEasy
@@ -21,11 +21,11 @@ Player:
 		Condition: AIShattered
 		Bots: ShatteredAI
 	HarvesterBotModule:
-		RequiresCondition: AIReload
+		RequiresCondition: AIBase
 		HarvesterTypes: harv, scrharv
 		RefineryTypes: gdiref, nodref, scrproc, cabproc, muproc
 	BaseBuilderBotModule@AINormal:
-		RequiresCondition: AIReload && !AIShattered
+		RequiresCondition: AIBase && !AIShattered
 		MinimumExcessPower: 90
 		MaximumExcessPower: 250
 		ExcessPowerIncrement: 50
@@ -374,9 +374,9 @@ Player:
 			cabtech: 6000
 			gadept: 6000
 	BuildingRepairBotModule:
-		RequiresCondition: AIReload
+		RequiresCondition: AIBase
 	SquadManagerBotModule@test:
-		RequiresCondition: AIReload
+		RequiresCondition: AIBase
 		SquadSize: 35
 		SquadSizeRandomBonus: 30
 		ExcludeFromSquadsTypes: harv, cabharv, scrharv, harv.gdi, harv.nod, harv.mut, harv.cab, engineer, e2, swarmling, shapeshifter,mcv, drache, drache_bot, cabmcv, nodmcv, mutmcv, repairvehicle
@@ -391,7 +391,7 @@ Player:
 		AttackScanRadius: 14
 		ProtectionScanRadius: 15
 	UnitBuilderBotModule@test:
-		RequiresCondition: AIReload
+		RequiresCondition: AIBase
 		UnitQueues: Infantry, Vehicle, Air
 		IdleBaseUnitsMaximum: 60
 		UnitsToBuild:
@@ -525,7 +525,7 @@ Player:
 		McvFactoryTypes: gaweap, naweap, muweap, cabweap, scrair
 		MinimumConstructionYardCount: 5
 	SupportPowerBotASModule:
-		RequiresCondition: AIReload
+		RequiresCondition: AIBase
 		Decisions:
 			gdiradarscan:
 				OrderName: GDIRadarScan

--- a/mods/sp/rules/ai.yaml
+++ b/mods/sp/rules/ai.yaml
@@ -398,7 +398,7 @@ Player:
 			harv: 90
 			scrharv: 90
 			cabharv: 90
-			gdie1: 5
+			gdie1: 1
 			altnode1: 5
 			pdrone: 5
 			shark: 1
@@ -410,8 +410,8 @@ Player:
 			cyborg: 15
 			cborg: 15
 			legio: 20
-			grenadier: 5
-			medic: 5
+			grenadier: 20
+			medic: 50
 			templar: 10
 			mutfiend: 3
 			reapercab: 20
@@ -424,8 +424,8 @@ Player:
 			cyc2: 30
 			float: 3
 			bug: 30
-			mmch: 50
-			smech: 1
+			mmch: 30
+			smech: 60
 			riflebggy: 1
 			rocketbggy: 1
 			flamebggy: 10
@@ -441,7 +441,7 @@ Player:
 			lynx: 50
 			mutquad: 30
 			wolf: 5
-			g4tnk: 90
+			g4tnk: 20
 			scrmbt: 1
 			sonic: 5
 			jug: 40
@@ -472,7 +472,7 @@ Player:
 			scrmobmine: 5
 			mutqueen: 1
 			lazorbggy: 15
-			apc_bot: 20
+			apc_bot: 1
 			moth: 2
 			nukecarryall_bot: 5
 			sonicarryall_bot: 5
@@ -488,7 +488,6 @@ Player:
 			scrmobmine: 2
 			mrls: 1
 			repairvehicle: 2
-			medic: 5
 			engineer: 1
 			e2: 1
 			swarmling: 1

--- a/mods/sp/rules/ai.yaml
+++ b/mods/sp/rules/ai.yaml
@@ -415,7 +415,7 @@ Player:
 			templar: 10
 			mutfiend: 3
 			reapercab: 20
-			colossi: 5
+			colossi: 1
 			seer: 10
 			eagleguard: 1
 			bhs: 30
@@ -495,6 +495,7 @@ Player:
 			scrdestroyer: 3
 			devourer: 5
 			bike: 1
+			colossi: 3
 			## nukecarryall_bot: 1 but not restrict here
 			## sonicarryall_bot: 1 but not restrict here
 		UnitDelays:

--- a/mods/sp/rules/aircraft.yaml
+++ b/mods/sp/rules/aircraft.yaml
@@ -656,7 +656,7 @@ NUKECARRYALL_BOT:
 		Description: AI Nuke Transport
 		Queue: Air
 		BuildPaletteOrder: 6
-		Prerequisites: ~muair, muhall, ~AImoney, ~!LoadedExists
+		Prerequisites: ~muair, muhall, ~AIOnly, ~!LoadedExists
 	Selectable:
 		Class: trnsport
 	Valued:
@@ -704,7 +704,7 @@ SONICARRYALL_BOT:
 		Description: AI Sonic Transport
 		Queue: Air
 		BuildPaletteOrder: 6
-		Prerequisites: ~gahpad, gatech, ~AImoney, ~!LoadedExists
+		Prerequisites: ~gahpad, gatech, ~AIOnly, ~!LoadedExists
 	Valued:
 		Cost: 1200
 	Cargo:

--- a/mods/sp/rules/creeps.yaml
+++ b/mods/sp/rules/creeps.yaml
@@ -229,7 +229,7 @@ BERSERKER:
 	WithInfantryBody:
 		Sequence: shoot
 		IdleSequences: idle1, idle2, idle3
-		RequiresCondition: WebDisable
+		RequiresCondition: !WebDisable
 	AttackFrontal:
 		Voice: Attack
 	AttackWander:

--- a/mods/sp/rules/creeps.yaml
+++ b/mods/sp/rules/creeps.yaml
@@ -173,6 +173,7 @@ ZOMBIE:
 		Weapon: SlimeAttack
 	WithInfantryBody:
 		AttackSequences: shoot
+		RequiresCondition: !WebDisable
 	AttackFrontal:
 		Voice: Attack
 		PauseOnCondition: WebDisable

--- a/mods/sp/rules/defaults.yaml
+++ b/mods/sp/rules/defaults.yaml
@@ -871,13 +871,13 @@
 ^UsesAmmunition:
 	AmmoPool:
 		Ammo: 8
-	ReloadAmmoPool@AIReload:
+	ReloadAmmoPool@AIBase:
 		AmmoPool: primary
-		RequiresCondition: AIReload
+		RequiresCondition: AIBase
 		Count: 10
 		Delay: 1500
-	GrantConditionOnBotOwner@AIReload:
-		Condition: AIReload
+	GrantConditionOnBotOwner@AIBase:
+		Condition: AIBase
 		Bots: CheaterAI, EasyAI, ShatteredAI
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
@@ -885,23 +885,23 @@
 
 ^AICashCheat:
 	CashTrickler@AICashDevour:
-		Interval: 1100
-		Amount: 800
+		Interval: 500
+		Amount: 400
 		ShowTicks: false
 		RequiresCondition: AIShattered
 	CashTrickler@AICashCheater:
-		Interval: 1000
-		Amount: 350
+		Interval: 500
+		Amount: 200
 		ShowTicks: false
 		RequiresCondition: AICheater
 	CashTrickler@AICashNormal:
-		Interval: 600
+		Interval: 500
 		Amount: 50
 		ShowTicks: false
-		RequiresCondition: AIReload || AICheater
-	GrantConditionOnBotOwner@AIReload:
-		Condition: AIReload
-		Bots: CheaterAI, EasyAI
+		RequiresCondition: AIEasy
+	GrantConditionOnBotOwner@AIEasy:
+		Condition: AIEasy
+		Bots: EasyAI
 	GrantConditionOnBotOwner@AICheater:
 		Condition: AICheater
 		Bots: CheaterAI
@@ -918,12 +918,9 @@
 	GrantConditionOnBotOwner@AIbuildingMicroControl:
 		Condition: AIbuildingMicroControl
 		Bots: CheaterAI, EasyAI, ShatteredAI
-	ProvidesPrerequisite@AISpecialProduce:
-		RequiresCondition: AIbuildingMicroControl
-		Prerequisite: AImoney
-	ProvidesPrerequisite@fixUndeployDracheBug:
-		RequiresCondition: AIbuildingMicroControl
-		Prerequisite: fixUndeployDracheBug
+	GrantConditionOnBotOwner@AISpecialProduce:
+		Condition: AISpecialProduce
+		Bots: CheaterAI, ShatteredAI
 
 ^GenericEffects:
 	Inherits@0: ^KillSelf

--- a/mods/sp/rules/sharedrules.yaml
+++ b/mods/sp/rules/sharedrules.yaml
@@ -396,11 +396,14 @@ GACNST:
 	ProvidesPrerequisite@AIantiRush:
 		RequiresCondition: !AIbuildingMicroControl
 		Prerequisite: AIantiRush
+	IsometricSelectable:
+		DecorationHeight: 36
+	ProvidesPrerequisite@AISpecialProduce:
+		RequiresCondition: AISpecialProduce
+		Prerequisite: AIOnly
 	Power@AICheatPower:
 		RequiresCondition: AIShattered
 		Amount: 80
-	IsometricSelectable:
-		DecorationHeight: 36
 
 ^Powerplant:
 	Inherits: ^Building
@@ -448,6 +451,9 @@ GACNST:
 		Condition: produced
 	ProvidesPrerequisite@AIantiRush:
 		Prerequisite: AIantiRush
+	ProvidesPrerequisite@AISpecialProduce:
+		RequiresCondition: AISpecialProduce
+		Prerequisite: AIOnly
 
 ^RefineryHP:
 	Health:
@@ -673,6 +679,9 @@ FLIPPEDYPROC:
 		Prerequisite: AIantiRush
 	IsometricSelectable:
 		DecorationHeight: 48
+	ProvidesPrerequisite@AISpecialProduce:
+		RequiresCondition: AISpecialProduce
+		Prerequisite: AIOnly
 
 ^Helipad:
 	Inherits: ^Building
@@ -708,6 +717,9 @@ FLIPPEDYPROC:
 		PauseOnCondition: disabled
 	ProvidesPrerequisite@AIantiRush:
 		Prerequisite: AIantiRush
+	ProvidesPrerequisite@AISpecialProduce:
+		RequiresCondition: AISpecialProduce
+		Prerequisite: AIOnly
 
 ^Radar:
 	Inherits: ^Building

--- a/mods/sp/rules/structures.yaml
+++ b/mods/sp/rules/structures.yaml
@@ -1217,6 +1217,9 @@ SCRAIR:
 		AreaTypes: building
 	IsometricSelectable:
 		DecorationHeight: 72
+	ProvidesPrerequisite@fixAIUndeployDracheBug:
+		RequiresCondition: AIbuildingMicroControl
+		Prerequisite: fixUndeployDracheBug
 
 SCRTECH:
 	Inherits: ^TechCenter

--- a/mods/sp/rules/support.yaml
+++ b/mods/sp/rules/support.yaml
@@ -259,7 +259,7 @@ MUBUNKRFULL:
 	IsometricSelectable:
 		Class: mubunkr
 	Valued:
-		Cost: 1050
+		Cost: 850
 	GivesExperience:
 		Experience: 500
 	RenderSprites:
@@ -267,7 +267,6 @@ MUBUNKRFULL:
 	EditorOnlyTooltip:
 		Name: Filled Bunker
 	Cargo:
-		EjectOnDeath: true
 		InitialUnits: marauder, marauder, mutfiend, marauder, marauder
 
 MUCANNON:

--- a/mods/sp/rules/support.yaml
+++ b/mods/sp/rules/support.yaml
@@ -197,7 +197,7 @@ MUBUNKR:
 		Description: Fortified position where infantry can fire from within.\n\nGood vs: Depends what has been garrisoned\n\nSpecial:\n- Provides stealth detection when garrisoned.\n- Infantry units can be garrisoned inside, gaining extra range.\n- Comes with a free marauder.\n- Does not require power to operate.
 		Queue: Defense
 		BuildPaletteOrder: 16
-		Prerequisites: murax, ~structures.mut, ~!AImoney
+		Prerequisites: murax, ~structures.mut, ~!AIOnly
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -255,7 +255,7 @@ MUBUNKR:
 MUBUNKRFULL:
 	Inherits: MUBUNKR
 	Buildable:
-		Prerequisites: murax, ~structures.mut, ~AImoney
+		Prerequisites: murax, ~structures.mut, ~AIOnly
 	IsometricSelectable:
 		Class: mubunkr
 	Valued:

--- a/mods/sp/rules/vehicles.yaml
+++ b/mods/sp/rules/vehicles.yaml
@@ -166,7 +166,7 @@ APC:
 APC_BOT:
 	Inherits: APC
 	Valued:
-		Cost: 1450
+		Cost: 1100
 	Selectable:
 		Class: apc
 	GivesExperience:
@@ -176,8 +176,7 @@ APC_BOT:
 	Buildable:
 		Prerequisites: ~gaweap, gapile, ~AImoney
 	Cargo:
-		EjectOnDeath: true
-		InitialUnits: gdie1, gdie1, gdie1, gdie1, grenadier
+		InitialUnits: gdie1, gdie1, medic, gdie1, grenadier
 	AIDeployHelper:
 
 HVR:
@@ -797,7 +796,7 @@ BGGY:
 RIFLEBGGY:
 	Inherits: BGGY
 	Valued:
-		Cost: 400
+		Cost: 350
 	Selectable:
 		Class: bggy
 	GivesExperience:
@@ -809,13 +808,12 @@ RIFLEBGGY:
 	Buildable:
 		Prerequisites: ~naweap, ~AImoney
 	Cargo:
-		EjectOnDeath: true
 		InitialUnits: altnode1
 
 ROCKETBGGY:
 	Inherits: BGGY
 	Valued:
-		Cost: 600
+		Cost: 450
 	Selectable:
 		Class: bggy
 	GivesExperience:
@@ -827,13 +825,12 @@ ROCKETBGGY:
 	Buildable:
 		Prerequisites: ~naweap, ~AImoney
 	Cargo:
-		EjectOnDeath: true
 		InitialUnits: crusader
 
 FLAMEBGGY:
 	Inherits: BGGY
 	Valued:
-		Cost: 600
+		Cost: 450
 	Selectable:
 		Class: bggy
 	GivesExperience:
@@ -843,7 +840,6 @@ FLAMEBGGY:
 	Buildable:
 		Prerequisites: ~naweap, naradr, ~AImoney
 	Cargo:
-		EjectOnDeath: true
 		InitialUnits: templar
 	EditorOnlyTooltip:
 		Name: Flame Buggy
@@ -851,7 +847,7 @@ FLAMEBGGY:
 LAZORBGGY:
 	Inherits: BGGY
 	Valued:
-		Cost: 1000
+		Cost: 700
 	Selectable:
 		Class: bggy
 	GivesExperience:
@@ -861,7 +857,6 @@ LAZORBGGY:
 	Buildable:
 		Prerequisites: ~naweap, natech, ~AImoney
 	Cargo:
-		EjectOnDeath: true
 		InitialUnits: nconf
 	EditorOnlyTooltip:
 		Name: Laser Buggy
@@ -1449,11 +1444,10 @@ STRUCKFULL:
 	Buildable:
 		Prerequisites: ~muweap, murax, ~AImoney
 	Valued:
-		Cost: 1400
+		Cost: 9500
 	GivesExperience:
 		Experience: 500
 	Cargo:
-		EjectOnDeath: true
 		InitialUnits: marauder, marauder, mutfiend, mutfiend, e3
 	RenderSprites:
 		Image: struck

--- a/mods/sp/rules/vehicles.yaml
+++ b/mods/sp/rules/vehicles.yaml
@@ -174,7 +174,7 @@ APC_BOT:
 	RenderSprites:
 		Image: apc
 	Buildable:
-		Prerequisites: ~gaweap, gapile, ~AImoney
+		Prerequisites: ~gaweap, gapile, ~AIOnly
 	Cargo:
 		InitialUnits: gdie1, gdie1, medic, gdie1, grenadier
 	AIDeployHelper:
@@ -502,7 +502,7 @@ BGGY:
 		BuildAtProductionType: Tank
 		Description: Fast vehicle armed with a machine, has room for one passenger that modifies the weapon of the vehicle.\n\nGood vs: Changes depending on the passenger.\n\nSpecial:\n- The weapon of the vehicle changes with the passenger.\n- Stealth detection.\n- Units inside deal 20% extra damage.
 		BuildPaletteOrder: 10
-		Prerequisites: ~naweap, ~!AImoney
+		Prerequisites: ~naweap, ~!AIOnly
 	Mobile:
 		TurnSpeed: 40
 		Speed: 125
@@ -806,7 +806,7 @@ RIFLEBGGY:
 	RenderSprites:
 		Image: bggy
 	Buildable:
-		Prerequisites: ~naweap, ~AImoney
+		Prerequisites: ~naweap, ~AIOnly
 	Cargo:
 		InitialUnits: altnode1
 
@@ -823,7 +823,7 @@ ROCKETBGGY:
 	RenderSprites:
 		Image: bggy
 	Buildable:
-		Prerequisites: ~naweap, ~AImoney
+		Prerequisites: ~naweap, ~AIOnly
 	Cargo:
 		InitialUnits: crusader
 
@@ -838,7 +838,7 @@ FLAMEBGGY:
 	RenderSprites:
 		Image: bggy
 	Buildable:
-		Prerequisites: ~naweap, naradr, ~AImoney
+		Prerequisites: ~naweap, naradr, ~AIOnly
 	Cargo:
 		InitialUnits: templar
 	EditorOnlyTooltip:
@@ -855,7 +855,7 @@ LAZORBGGY:
 	RenderSprites:
 		Image: bggy
 	Buildable:
-		Prerequisites: ~naweap, natech, ~AImoney
+		Prerequisites: ~naweap, natech, ~AIOnly
 	Cargo:
 		InitialUnits: nconf
 	EditorOnlyTooltip:
@@ -1406,7 +1406,7 @@ STRUCK:
 		Description: Combat transport.\n\nGood vs: Depends what has been garrisoned\n\nSpecial:\n- Cargo for 5 soldiers.\n- Passengers can fire from inside the vehicle.
 		Queue: Vehicle
 		BuildPaletteOrder: 19
-		Prerequisites: ~muweap, murax, ~!AImoney
+		Prerequisites: ~muweap, murax, ~!AIOnly
 	Mobile:
 		TurnSpeed: 24
 		Speed: 95
@@ -1442,7 +1442,7 @@ STRUCKFULL:
 	Selectable:
 		Class: struck
 	Buildable:
-		Prerequisites: ~muweap, murax, ~AImoney
+		Prerequisites: ~muweap, murax, ~AIOnly
 	Valued:
 		Cost: 9500
 	GivesExperience:

--- a/mods/sp/weapons/cabweapons.yaml
+++ b/mods/sp/weapons/cabweapons.yaml
@@ -239,7 +239,7 @@ WorkerMinigun:
 	Report: infgun3.aud, gostgun1.aud, slvkgun1.aud
 	Warhead@1Dam: SpreadDamage
 		Damage: 1600
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 
 Dogzooka:
 	Inherits: JJGrenade


### PR DESCRIPTION
1. Delete `EjectOnDeath` on AI pre-load units due to it is buggy now with new engine. Reduce the price of all preload units

2. Move AI prerequisites to low level YAML class to improve performance (update `Techtree` is time costing), Easy AI cannot build certain unit (pre-load units) now, and it is no longer a punch bag that bite back.

3. GDI AI squad adjusted, since the fully loaded APC now is a high risk choice in combat.