### PR TITLE
Wild visceroid enhance -- spawn small ones when killed

### DIFF
--- a/mods/sp/rules/creeps.yaml
+++ b/mods/sp/rules/creeps.yaml
@@ -120,6 +120,22 @@ VISC_LRG:
 		Crushes: nada
 	RenderSprites:
 		Image: vislrg
+	SpawnActorOnDeath@smallVisceroid1:
+		Actor: visc_sml
+		Probability: 100
+		OwnerType: InternalName
+		InternalOwner: Creeps
+		RequiresLobbyCreeps: true
+	SpawnActorOnDeath@smallVisceroid2:
+		Actor: visc_sml
+		Probability: 100
+		OwnerType: InternalName
+		InternalOwner: Creeps
+		RequiresLobbyCreeps: true
+	Explodes@adultExplodes:
+		Weapon: ZombieExplosion
+		EmptyWeapon: ZombieExplosion
+		Chance: 100
 
 VISC_LRG_SCRIN:
 	Inherits: VISC_LRG
@@ -143,6 +159,9 @@ VISC_LRG_SCRIN:
 		StartIfBelow: 200
 	RenderSprites:
 		Image: vislrg
+	-SpawnActorOnDeath@smallVisceroid1:
+	-SpawnActorOnDeath@smallVisceroid2:
+	-Explodes@adultExplodes:
 
 ZOMBIE:
 	Inherits: ^Mutant


### PR DESCRIPTION
This makes Wild Visceroid enhanced, but just a little bit, and it is an idea that imitating that in original TS the Wild Visceroid will escape when at low health, and find a place to restore its health and strength, but surely, more than imitating.

Player can just leave Wild Visceroid along for it won't do damage more than gun, but if player decide to kill it, they have to kill two small parts as well, or they will multiply just like cockroachs in your kitchen.

Update:
Big Visceroid will explode violently, just like Haunted or Berserker does.