### PR TITLE
Fix owner on Visceroid death spawning

### DIFF
--- a/mods/sp/rules/creeps.yaml
+++ b/mods/sp/rules/creeps.yaml
@@ -123,15 +123,11 @@ VISC_LRG:
 	SpawnActorOnDeath@smallVisceroid1:
 		Actor: visc_sml
 		Probability: 100
-		OwnerType: InternalName
-		InternalOwner: Creeps
-		RequiresLobbyCreeps: true
+		OwnerType: Victim
 	SpawnActorOnDeath@smallVisceroid2:
 		Actor: visc_sml
 		Probability: 100
-		OwnerType: InternalName
-		InternalOwner: Creeps
-		RequiresLobbyCreeps: true
+		OwnerType: Victim
 	Explodes@adultExplodes:
 		Weapon: ZombieExplosion
 		EmptyWeapon: ZombieExplosion

--- a/mods/sp/rules/structures.yaml
+++ b/mods/sp/rules/structures.yaml
@@ -631,6 +631,9 @@ NAMISL:
 		CameraSpawnAdvance: 25
 		CameraRemoveDelay: 350
 		PauseOnCondition: empdisable || disabled
+		TrailImage: meteortrail
+		TrailPalette: effectalpha
+		TrailSequences: idle3
 	Health:
 		HP: 300000
 	WithDecoration@POWERDOWN:

--- a/mods/sp/rules/support.yaml
+++ b/mods/sp/rules/support.yaml
@@ -811,6 +811,9 @@ NASTLH:
 		CircleSequence: circles
 		FlightDelay: 400
 		PauseOnCondition: empdisable || disabled
+		TrailImage: meteortrail
+		TrailPalette: effectalpha
+		TrailSequences: idle2
 
 NATMPL:
 	Inherits: ^Building

--- a/mods/sp/sequences/misc.yaml
+++ b/mods/sp/sequences/misc.yaml
@@ -604,6 +604,16 @@ meteortrail:
 		Tick: 25
 		ZOffset: 3000
 		BlendMode: Additive
+	idle2:
+		Length: *
+		ZOffset: 3000
+		BlendMode: Additive
+	idle3:
+		Start: 10
+		Length: *
+		ZOffset: 3000
+		Tick: 75
+		BlendMode: Additive
 
 largefire:
 	idle: fire1
@@ -723,7 +733,7 @@ clustermissile:
 	down: atnukemini
 		Start: 1
 		ZOffset: 1023
-		Offset: 0,-50
+		Offset: 0, 35
 
 healernuke:
 	up: atnukemini
@@ -732,7 +742,7 @@ healernuke:
 	down: atnukemini
 		Start: 1
 		ZOffset: 1023
-		Offset: 0,-50
+		Offset: 0, 35
 
 toxinmissile:
 	up: chemnuke


### PR DESCRIPTION
Now the spawned small visceroids will correctly belong to the original owner including creeps, instead of only creeps.