### PR TITLE
ver all contrails & offset fixes for aircrafts and other fixes

### DIFF
--- a/mods/sp/rules/aircraft.yaml
+++ b/mods/sp/rules/aircraft.yaml
@@ -463,10 +463,10 @@ CERBERUS:
 		HP: 45000
 	Armament@sweep1:
 		Weapon: CerberusSublazor1
-		LocalOffset: 1700, 0, 0
+		LocalOffset: 1100, 0, 0
 	Armament@sweep2:
 		Weapon: CerberusSublazor2
-		LocalOffset: 1700, 0, 0
+		LocalOffset: 1100, 0, 0
 	AttackAircraft:
 		AttackType: Hover
 		FacingTolerance: 10
@@ -489,25 +489,25 @@ CERBERUS:
 		Weapon: BigAircraftShrapnel
 		EmptyWeapon: BigAircraftShrapnel
 	Contrail@1:
-		Offset: -1700, 336,-600
+		Offset: -1500, 336, -50
 		Color: FFEA0080
 		UsePlayerColor: false
 		TrailLength: 10
 		TrailWidth: 128
 	Contrail@2:
-		Offset: -1700, 112,-600
+		Offset: -1500, 112, -50
 		Color: FFEA0080
 		UsePlayerColor: false
 		TrailLength: 10
 		TrailWidth: 128
 	Contrail@3:
-		Offset: -1700, -112,-600
+		Offset: -1500, -112, -50
 		Color: FFEA0080
 		UsePlayerColor: false
 		TrailLength: 10
 		TrailWidth: 128
 	Contrail@4:
-		Offset: -1700, -336,-600
+		Offset: -1500, -336, -50
 		Color: FFEA0080
 		UsePlayerColor: false
 		TrailLength: 10
@@ -641,15 +641,15 @@ WETP:
 		EmptySequence: pip-ammoempty
 		Palette: pips
 	Contrail@1:
-		Offset: -100,-700,0
-		Color: 555555
+		Offset: -100,-700,55
+		Color: 55555580
 		UsePlayerColor: false
 	Contrail@2:
-		Offset: -100,700,0
-		Color: 555555
+		Offset: -100,700,55
+		Color: 55555580
 		UsePlayerColor: false
 	Contrail@FlameTrail:
-		Offset: -1000,0,-100
+		Offset: -900,0,50
 		Color: FFEA0080
 		UsePlayerColor: false
 		TrailWidth: 128
@@ -838,12 +838,12 @@ STORMRIDER:
 		Image: scrsmoke
 		Palette: gradientblue40
 	Contrail@1:
-		Offset: -300,-143,0
-		Color: 33008880
+		Offset: -300,-150,-100
+		Color: 33008860
 		UsePlayerColor: false
 	Contrail@2:
-		Offset: -300,143,0
-		Color: 33008880
+		Offset: -300,150,-100
+		Color: 3300EE80
 		UsePlayerColor: false
 
 ^ScrinAircraftGeneric:
@@ -1013,6 +1013,12 @@ SCRDESTROYER:
 		QuantizedFacings: 32
 	SpawnActorOnDeath:
 		Actor: SCRDESTROYER.Husk
+	Contrail@1:
+		Offset: -1300, -20, 600
+		Color: AAAAFFAA
+		UsePlayerColor: false
+		TrailLength: 10
+		TrailWidth: 128
 
 SCRTRANS:
 	Inherits: ^Helicopter
@@ -1052,6 +1058,12 @@ SCRTRANS:
 	WithCargoPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
+	Contrail@1:
+		Offset: -1600, -20, 100
+		Color: AAAAFFAA
+		UsePlayerColor: false
+		TrailLength: 10
+		TrailWidth: 128
 
 SCRCARRIER:
 	Inherits: ^CombatHelicopter
@@ -1107,6 +1119,12 @@ SCRCARRIER:
 		Palette: pips
 		Position: BottomLeft
 		RequiresSelection: true
+	Contrail@1:
+		Offset: -1300, -20, 100
+		Color: AAAAFFAA
+		UsePlayerColor: false
+		TrailLength: 10
+		TrailWidth: 128
 
 STORMRIDERSPAWN:
 	Inherits: STORMRIDER
@@ -1159,8 +1177,8 @@ STORMRIDERSPAWN:
 	-SelectionDecorations:
 	Interactable:
 	Contrail@1:
-		Offset: 0,0,0
-		Color: 33008880
+		Offset: 0,-30,0
+		Color: 3300EE80
 		UsePlayerColor: false
 		TrailWidth: 32
 
@@ -1236,6 +1254,24 @@ SCRBATTLESHIP:
 		QuantizedFacings: 32
 	SpawnActorOnDeath:
 		Actor: SCRBATTLESHIP.Husk
+	Contrail@1:
+		Offset: -2200, -20, 350
+		Color: AAAAFFAA
+		UsePlayerColor: false
+		TrailLength: 15
+		TrailWidth: 128
+	Contrail@2:
+		Offset: -2300, 80, 350
+		Color: AA33FF80
+		UsePlayerColor: false
+		TrailLength: 8
+		TrailWidth: 128
+	Contrail@3:
+		Offset: -2300, -140, 350
+		Color: AA33FF80
+		UsePlayerColor: false
+		TrailLength: 8
+		TrailWidth: 128
 
 WASP:
 	Inherits: ^CombatHelicopter
@@ -1374,12 +1410,12 @@ BASILISK:
 		Weapon: BigAircraftShrapnel
 		EmptyWeapon: BigAircraftShrapnel
 	Contrail@1:
-		Offset: -1000,-300,-300
+		Offset: -1000,-330,40
 		Color: FFEA0080
 		UsePlayerColor: false
 		TrailLength: 10
 	Contrail@2:
-		Offset: -1000,300,-300
+		Offset: -1000,300,40
 		Color: FFEA0080
 		UsePlayerColor: false
 		TrailLength: 10

--- a/mods/sp/rules/aircraft.yaml
+++ b/mods/sp/rules/aircraft.yaml
@@ -463,10 +463,10 @@ CERBERUS:
 		HP: 45000
 	Armament@sweep1:
 		Weapon: CerberusSublazor1
-		LocalOffset: 1100, 0, 0
+		LocalOffset: 1400, 225, 0
 	Armament@sweep2:
 		Weapon: CerberusSublazor2
-		LocalOffset: 1100, 0, 0
+		LocalOffset: 1400, -225, 0
 	AttackAircraft:
 		AttackType: Hover
 		FacingTolerance: 10

--- a/mods/sp/rules/aircraft.yaml
+++ b/mods/sp/rules/aircraft.yaml
@@ -145,9 +145,11 @@ ORCAB:
 		Bounds: 30,24
 	Aircraft:
 		MaximumPitch: 120
-		TurnSpeed: 16
+		TurnSpeed: 20
 		IdealSeparation: 256
 		Speed: 130
+		IdleTurnSpeed: 20
+		IdleSpeed: 85
 		AirborneCondition: airborne
 		MoveIntoShroud: true
 	Health:
@@ -391,6 +393,8 @@ SCRIN:
 		MaximumPitch: 90
 		TurnSpeed: 40
 		Speed: 170
+		IdleTurnSpeed: 20
+		IdleSpeed: 85
 		AirborneCondition: airborne
 		MoveIntoShroud: true
 	Health:
@@ -598,9 +602,10 @@ WETP:
 		Bounds: 30,24
 	Aircraft:
 		MaximumPitch: 120
-		TurnSpeed: 36
-		IdleTurnSpeed: 16
+		TurnSpeed: 30
+		IdleTurnSpeed: 20
 		Speed: 150
+		IdleSpeed: 85
 		AirborneCondition: airborne
 		MoveIntoShroud: true
 	Health:
@@ -812,6 +817,8 @@ STORMRIDER:
 		MaximumPitch: 90
 		TurnSpeed: 32
 		Speed: 170
+		IdleTurnSpeed: 20
+		IdleSpeed: 85
 		AirborneCondition: airborne
 		MoveIntoShroud: true
 	-Rearmable:

--- a/mods/sp/rules/sharedrules.yaml
+++ b/mods/sp/rules/sharedrules.yaml
@@ -1266,6 +1266,18 @@ trnsport.nod:
 	Inherits: trnsport.gdi
 	RenderSprites:
 		Image: nodcarryall
+	Contrail@1:
+		Offset: -850,-190,340
+		Color: FFEA0080
+		UsePlayerColor: false
+		TrailLength: 10
+		ZOffset: 4100
+	Contrail@2:
+		Offset: -850,190,340
+		Color: FFEA0080
+		UsePlayerColor: false
+		TrailLength: 10
+		ZOffset: 4100
 
 trnsport.mut:
 	Inherits: TRNSPORT
@@ -1297,6 +1309,18 @@ trnsport.cab:
 	Inherits: trnsport.gdi
 	RenderSprites:
 		Image: cabcarryall
+	Contrail@1:
+		Offset: -1200,-175, 40
+		Color: FFEA0080
+		UsePlayerColor: false
+		TrailLength: 10
+		ZOffset: 4100
+	Contrail@2:
+		Offset: -1200,175, 40
+		Color: FFEA0080
+		UsePlayerColor: false
+		TrailLength: 10
+		ZOffset: 4100
 
 NAPULS:
 	Inherits: ^Defence

--- a/mods/sp/weapons/nodweapons.yaml
+++ b/mods/sp/weapons/nodweapons.yaml
@@ -505,12 +505,12 @@ CerberusSublazor1:
 	ValidTargets: Ground, Water
 	Projectile: LaserZap
 		TrackTarget: false
-		Width: 60
+		Width: 45
 		Duration: 2
 		ZOffset: 4000
 		Color: FF0000
 		SecondaryBeam: true
-		SecondaryBeamWidth: 80
+		SecondaryBeamWidth: 22
 		SecondaryBeamZOffset: 4000
 		SecondaryBeamColor: FFFF00
 	InvalidTargets: Air

--- a/mods/sp/weapons/nodweapons.yaml
+++ b/mods/sp/weapons/nodweapons.yaml
@@ -494,11 +494,11 @@ CerberusLazor:
 		DamageTypes: Prone60Percent, TriggerProne, EnergyDeath
 
 CerberusSublazor1:
-	FirstBurstTargetOffset: 0,-800,0
-	FollowingBurstTargetOffset: 0,80,0
-	ReloadDelay: 120
+	FirstBurstTargetOffset: -180,-810,0
+	FollowingBurstTargetOffset: 20,90,0
+	ReloadDelay: 140
 	Range: 7c0
-	Burst: 20
+	Burst: 18
 	BurstDelays: 1
 	MinRange: 4c0
 	Report: obelpowr.aud
@@ -516,12 +516,12 @@ CerberusSublazor1:
 	InvalidTargets: Air
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
-		Damage: 800
+		Damage: 900
 		Versus:
 			DefenseArmor: 75
 		ValidTargets: Ground, Water, water, Infantry, Vehicle, Building
 		InvalidTargets: Air
-		DamageTypes: Prone60Percent, TriggerProne, EnergyDeath
+		DamageTypes: Prone100Percent, TriggerProne, EnergyDeath
 	Warhead@1Eff_impact: CreateEffect
 		Explosions: laserscorch
 		ExplosionPalette: gradientgray
@@ -530,10 +530,10 @@ CerberusSublazor1:
 
 CerberusSublazor2:
 	Inherits: CerberusSublazor1
-	FirstBurstTargetOffset: 0,800,0
-	FollowingBurstTargetOffset: 0,-80,0
+	FirstBurstTargetOffset: -180,810,0
+	FollowingBurstTargetOffset: 20,-90,0
 	Warhead@1Dam: SpreadDamage
-		DamageTypes: Prone60Percent, TriggerProne, FireDeath
+		DamageTypes: Prone100Percent, TriggerProne, FireDeath
 
 TurretLaserFire:
 	Inherits: ^FullDamage


### PR DESCRIPTION
1. Idle speed for not-hover aircrafts. Make the easy to pick up by players when idle, and looks nicer.

2. Paladin lasers cross

3. Over all contrails & offset fixes

![1](https://user-images.githubusercontent.com/13763394/92738936-fa743400-f3ae-11ea-9566-d7221b2c1ef2.gif)
![4](https://user-images.githubusercontent.com/13763394/92738954-fe07bb00-f3ae-11ea-92fb-b8e24c8d9e58.gif)
![3](https://user-images.githubusercontent.com/13763394/92738959-ff38e800-f3ae-11ea-9199-0574f8834fd4.gif)
![2](https://user-images.githubusercontent.com/13763394/92738967-006a1500-f3af-11ea-9be2-37db52615a66.gif)
