### PR TITLE
Polish mines and eggs, add ^NonBuildingStaticActor

### DIFF
--- a/mods/sp/rules/aircraft.yaml
+++ b/mods/sp/rules/aircraft.yaml
@@ -988,7 +988,7 @@ SCRGLYDER1:
 		HP: 20000
 	Armament:
 		Weapon: Glyder1Cannon
-		LocalOffset: 0,0,-100
+		LocalOffset: 0,0,0
 	AttackAircraft:
 		AttackType: Hover
 		FacingTolerance: 20

--- a/mods/sp/rules/creeps.yaml
+++ b/mods/sp/rules/creeps.yaml
@@ -324,8 +324,7 @@ EGGS:
 		Locomotor: Vehicle
 	Armor:
 		Type: BuildingArmor
-	RevealsShroud:
-		Range: 4c0
+	-RevealsShroud:
 	Health:
 		HP: 50000
 	RenderSprites:

--- a/mods/sp/rules/creeps.yaml
+++ b/mods/sp/rules/creeps.yaml
@@ -317,9 +317,11 @@ BERSERKER:
 		Categories: Creep
 
 EGGS:
-	Inherits: ^IWantToRunButICanMove
+	Inherits: ^NonBuildingStaticActor
 	Tooltip:
 		Name: Crab Eggs (Menacing)
+	Mobile:
+		Locomotor: Vehicle
 	Armor:
 		Type: BuildingArmor
 	RevealsShroud:
@@ -329,7 +331,7 @@ EGGS:
 	RenderSprites:
 		Palette: playermut
 	Targetable:
-		TargetTypes: Defence, Ground, C4, NeutralTibCritter
+		TargetTypes: Defence, Ground, NeutralTibCritter, MindControlInmune
 	ExternalCondition@SpawnCrabs:
 		Condition: SpawnCrabs
 	GrantPeriodicCondition:
@@ -351,7 +353,6 @@ EGGS:
 		RequiresLobbyCreeps: true
 	MapEditorData:
 		Categories: Creep
-	-ThrowsShrapnel:
 
 CRAB:
 	Inherits: ^Beast

--- a/mods/sp/rules/defaults.yaml
+++ b/mods/sp/rules/defaults.yaml
@@ -413,6 +413,9 @@
 
 ^MindControllable:
 	WithMindControlArc:
+		ZOffset: 8000
+		Transparency: 64
+		QuantizedSegments: 28
 	MindControllable:
 		RevokeControlSounds: bleep5.aud
 

--- a/mods/sp/rules/defaults.yaml
+++ b/mods/sp/rules/defaults.yaml
@@ -1864,16 +1864,6 @@
 	Inherits@2: ^VehicleEffects
 	Inherits@3: ^ExistsInWorld
 
-^IWantToRunButICanMove:
-	Inherits@0: ^BasicVehicle
-	Mobile:
-		Locomotor: Vehicle
-		TurnSpeed: 28
-		Voice: Move
-		RequiresCondition: !IWantToRunButICanMove
-	GrantCondition@IWantToRunButICanMove:
-		Condition: IWantToRunButICanMove
-
 ^Tank:
 	Inherits: ^Vehicle
 	Inherits@2: ^AutoTargetGroundAssaultMove
@@ -2680,3 +2670,29 @@
 	IsometricSelectionDecorations:
 	WithTextControlGroupDecoration:
 		Margin: 1, 1
+
+^NonBuildingStaticActor:
+	Inherits: ^1x1Shape
+	Inherits@1: ^GenericEffects
+	Inherits@3: ^SpriteActor
+	Inherits@2: ^ExistsInWorld
+	Inherits@5: ^5CellVision
+	HiddenUnderFog:
+	Interactable:
+	Mobile:
+		Speed: 0
+		Locomotor: Infantry
+	Valued:
+		Cost: 1
+	RevealsShroud:
+		RequiresCondition: !inside-tunnel
+		Type: CenterPosition
+		MaxHeightDelta: 3
+		Range: 4c0
+	Health:
+		HP: 100
+	BodyOrientation:
+		QuantizedFacings: 1
+	WithSpriteBody:
+	RenderSprites:
+	Huntable:

--- a/mods/sp/rules/dummies.yaml
+++ b/mods/sp/rules/dummies.yaml
@@ -24,35 +24,22 @@
 	BodyOrientation:
 		QuantizedFacings: 32
 
+## Used for absolute timer with best performance, on the ground and static
+## No image and sight, pls add those function yourself if want new functions
 ^GROUNDDUMMY:
 	Inherits: ^1x1Shape
-	Inherits@1: ^GenericEffects
-	Inherits@3: ^SpriteActor
-	Inherits@2: ^ExistsInWorld
-	Inherits@5: ^5CellVision
 	HiddenUnderFog:
-	Interactable:
-	Mobile:
-		Speed: 0
-		Locomotor: Infantry
-	QuantizeFacingsFromSequence:
-		Sequence: stand
-	RenderSprites:
-		Image: blackhanddummy
-	Valued:
-		Cost: 1
-	RevealsShroud:
-		RequiresCondition: !inside-tunnel
-		Type: CenterPosition
-		MaxHeightDelta: 3
-		Range: 4c0
+	Immobile:
+		OccupiesSpace: false
 	Health:
 		HP: 100
 		NotifyAppliedDamage: false
-
+	BodyOrientation:
+		QuantizedFacings: 1
+	RenderDebugState:
 
 BigFireSpawnerDummy:
-	Inherits: ^DUMMYAIRCRAFT
+	Inherits: ^GROUNDDUMMY
 	ExplodeWeapon:
 		Weapon: BuildingFireBigShrapnel
 		ResetReloadWhenEnabled: false
@@ -454,6 +441,10 @@ FOGCAMERADUMMY:
 		StartIfBelow: 200
 		DamageCooldown: 25
 		RequiresCondition: !sustaincamera
+	RevealsShroud:
+		Type: CenterPosition
+		MaxHeightDelta: 3
+		Range: 4c0
 
 INFTIBSPAWN:
 	Inherits: ^DUMMYAIRCRAFT

--- a/mods/sp/rules/dummies.yaml
+++ b/mods/sp/rules/dummies.yaml
@@ -37,6 +37,7 @@
 	BodyOrientation:
 		QuantizedFacings: 1
 	RenderDebugState:
+	Interactable:
 
 BigFireSpawnerDummy:
 	Inherits: ^GROUNDDUMMY
@@ -122,8 +123,7 @@ RADARSCANDUMMY:
 		Palette: radarscanpalette
 
 IONBEAMTARGET:
-	Inherits: ^DUMMYAIRCRAFT
-	Inherits@3: ^1x1Shape
+	Inherits: ^GROUNDDUMMY
 	Tooltip:
 		Name: Target
 	Health:
@@ -266,9 +266,10 @@ IONBEAMMINI:
 		Weapon: IonScorch
 	HiddenUnderFog:
 		AlwaysVisibleStances: Ally, Enemy, Neutral
+	
 
 IONBEAMROAMER:
-	Inherits: ^DUMMYAIRCRAFT
+	Inherits: ^GROUNDDUMMY
 	Aircraft:
 		CruiseAltitude: 0
 		TurnSpeed: 80
@@ -314,10 +315,9 @@ IONBEAMROAMER:
 		Weapon: IonScorch
 
 KILLEDACTOR:
-	Inherits: ^DUMMYAIRCRAFT
+	Inherits: ^GROUNDDUMMY
 	ChangesHealth:
 		Step: -25
-		# PercentageStep: -50
 		StartIfBelow: 110
 		RequiresCondition: !nanomachineburst
 	Health:
@@ -335,13 +335,10 @@ KILLEDACTOR:
 		Condition: nanomachineburst
 
 NANOMACHINEBURSTSPAWNER:
-	Inherits: ^DUMMYAIRCRAFT
-	RenderSprites:
-		Image: blackhanddummy
+	Inherits: ^GROUNDDUMMY
 	ChangesHealth:
 		Step: -10
 		StartIfBelow: 200
-	-Tooltip:
 	Health:
 		HP: 5
 		NotifyAppliedDamage: false
@@ -394,10 +391,7 @@ NANOMACHINEBURSTDUMMY:
 	AutoTarget:
 
 EGGSPAWNER:
-	Inherits: ^DUMMYAIRCRAFT
-	Tooltip:
-		Name: Fire
-	-RevealsShroud:
+	Inherits: ^GROUNDDUMMY
 	Health:
 		HP: 1
 	ChangesHealth:
@@ -447,31 +441,39 @@ FOGCAMERADUMMY:
 		Range: 4c0
 
 INFTIBSPAWN:
-	Inherits: ^DUMMYAIRCRAFT
-	Tooltip:
-		Name: Fire
-	-RevealsShroud:
+	Inherits: ^GROUNDDUMMY
 	Health:
 		HP: 30
 	ChangesHealth:
 		Step: -30
 		Delay: 25
 		StartIfBelow: 200
-	Explodes:
-		Weapon: SpawnZombie
-		EmptyWeapon: SpawnZombie
-		RequiresCondition: zombie
-	Explodes@Visc:
-		Weapon: SpawnVisc
-		EmptyWeapon: SpawnVisc
-		RequiresCondition: visc
 	GrantRandomCondition:
 		Conditions: visc, zombie
+	SpawnActorOnDeath@zombie:
+		RequiresCondition: zombie
+		Actor: zombie
+		Probability: 100
+		OwnerType: InternalName
+		InternalOwner: Creeps
+		RequiresLobbyCreeps: true
+		SkipMakeAnimations: false
+	SpawnActorOnDeath@visc:
+		RequiresCondition: visc
+		Actor: visc_sml
+		Probability: 100
+		OwnerType: InternalName
+		InternalOwner: Creeps
+		RequiresLobbyCreeps: true
+		SkipMakeAnimations: false
+
 
 VEHICLETIBSPAWN:
 	Inherits: INFTIBSPAWN
-	Explodes:
-		Weapon: SpawnBerserker
+	SpawnActorOnDeath@zombie:
+		Actor: berserker
+	SpawnActorOnDeath@visc:
+		Actor: visc_lrg
 
 SCRINESSENCESMALL:
 	Inherits: ^DUMMYAIRCRAFT

--- a/mods/sp/rules/support.yaml
+++ b/mods/sp/rules/support.yaml
@@ -1389,29 +1389,28 @@ NAWAST:
 		FullSequence: pip-red
 
 MUMINE:
-	Inherits: ^IWantToRunButICanMove
+	Inherits: ^NonBuildingStaticActor
 	Inherits@1: ^3CellVision
 	Valued:
-		Cost: 50
+		Cost: 0
 	Tooltip:
 		Name: Mine
 	Health:
 		HP: 5000
-	-SpawnActorOnDeath@ScrinEssence:
 	Armor:
 		Type: Mine
 	Targetable:
 		TargetTypes: Ground, MindControlInmune, Mine
 	BodyOrientation:
-		QuantizedFacings: 32
+		QuantizedFacings: 1
 	Cloak@cloakgenerator:
-		-RequiresCondition:
 		CloakSound:
 		InitialDelay: 50
 		CloakDelay: 50
 		UncloakSound:
 		Palette: cloakmut
 		IsPlayerPalette: true
+		UncloakOn: Attack, Demolish
 	Mine:
 		CrushClasses: crate
 		DetonateClasses: crate
@@ -1421,6 +1420,8 @@ MUMINE:
 		Weapon: MineExplode
 	Targetable@Defence:
 		TargetTypes: Defence
+	RenderSprites:
+		Image: mumine
 
 MUWARD:
 	Inherits: ^DeployedVehicle
@@ -1472,9 +1473,3 @@ MUSTABLE:
 	RequiresBuildableArea:
 		AreaTypes: building
 
-SCRMINE:
-	Inherits: ^ScrinRender
-	Inherits@1: MUMINE
-	Tooltip:
-		Name: Scrin Mine
-	-Buildable:

--- a/mods/sp/rules/vehicles.yaml
+++ b/mods/sp/rules/vehicles.yaml
@@ -1896,6 +1896,14 @@ SCRMOBMINE:
 		Policy: DiscardOldest
 	Targetable@MindControlImmunity:
 		TargetTypes: MindControlInmune
+	ExplodeWeapon@Casing:
+		Weapon: MindEnergyCasing
+		LocalOffset: -200,0,1200
+		RequiresCondition: attack
+		RevokeDelay: 1
+	GrantConditionOnAttack@Casing:
+		Condition: attack
+		ArmamentNames: primary
 	Armament@PRIMARY:
 		Weapon: MindController
 		PauseOnCondition: empdisable

--- a/mods/sp/rules/vehicles.yaml
+++ b/mods/sp/rules/vehicles.yaml
@@ -1806,7 +1806,7 @@ SCRGLYDER2:
 		Weapon: Glyder2Cannon
 		Recoil: 85
 		RecoilRecovery: 25
-		LocalOffset: 100,0,1500
+		LocalOffset: -250,0,1300
 		PauseOnCondition: empdisable
 	AttackFrontal:
 		PauseOnCondition: empdisable

--- a/mods/sp/rules/zunused assets.yaml
+++ b/mods/sp/rules/zunused assets.yaml
@@ -346,45 +346,6 @@ NAWAST:
 	RequiresBuildableArea:
 		AreaTypes: building
 
-MUMINE:
-	Inherits: ^DeployedVehicle
-	Valued:
-		Cost: 100
-	Tooltip:
-		Name: Mine
-	Selectable:
-		Priority: 1
-	Health:
-		HP: 5000
-	-AttackTurreted:
-	-SpawnActorOnDeath@ScrinEssence:
-	-AutoTarget:
-	-RenderRangeCircle:
-	-ActorLostNotification:
-	-UpdatesPlayerStatistics:
-	-Voiced:
-	Armor:
-		Type: Mine
-	Targetable:
-		TargetTypes: Ground, Repair, MindControlInmune, Mine
-	BodyOrientation:
-		QuantizedFacings: 32
-	Cloak@cloakgenerator:
-		RequiresCondition: !lawea
-		CloakSound:
-		InitialDelay: 50
-		CloakDelay: 50
-		UncloakSound:
-		Palette: cloakmut
-		IsPlayerPalette: true
-		CloakTypes: mine
-	Mine:
-		CrushClasses: crate
-		DetonateClasses: crate
-		AvoidFriendly: true
-	Explodes:
-		Weapon: MineExplode
-
 MUWARD:
 	Inherits: ^DeployedVehicle
 	Valued:

--- a/mods/sp/sequences/explosions.yaml
+++ b/mods/sp/sequences/explosions.yaml
@@ -461,6 +461,7 @@ explosion:
 		Start: 27
 		Length: 1
 		ZOffset: -540
+	cldrngl1:cldrngl1
 
 buildingfire:
 	Defaults:

--- a/mods/sp/weapons/explosionweapons.yaml
+++ b/mods/sp/weapons/explosionweapons.yaml
@@ -522,7 +522,7 @@ BuildingFireBig:
 		ImpactActors: false
 		Duration: 75, 600
 		Image: explosion
-		Sequences: fire3, fire4
+		Sequences: fire1, fire2
 		Palette: effectalpha50
 
 BuildingFireSmall:
@@ -531,7 +531,7 @@ BuildingFireSmall:
 	MinRange: 0c512
 	Warhead@2: SpawnSmokeParticle
 		ImpactActors: false
-		Sequences: fire2, fire1
+		Sequences: fire3, fire4
 		Duration: 75, 300
 
 BuildingSmoke:

--- a/mods/sp/weapons/neutralweapons.yaml
+++ b/mods/sp/weapons/neutralweapons.yaml
@@ -351,33 +351,6 @@ BlueTibRadiation:
 	Warhead@8Radio: CreateTintedCells
 		LayerName: BlueRadiation
 
-SpawnVisc:
-	ReloadDelay: 25
-	Range: 2c0
-	Burst: 1
-	BurstDelays: 1
-	ValidTargets: ViscMale
-	Projectile: InstantHit
-	Warhead@1Dam: SpreadDamage
-		ValidTargets: ViscMale
-		Damage: 1
-		DamageTypes: Prone100Percent, TriggerProne, BulletDeath
-	Warhead@5Actor: SpawnActor
-		Actors: visc_sml
-		FallRate: 5000
-		Range: 3
-		ValidTargets: Ground, Water, Infantry, Air, Vehicle, Building, Wall
-
-SpawnZombie:
-	Inherits: SpawnVisc
-	Warhead@5Actor: SpawnActor
-		Actors: zombie
-
-SpawnBerserker:
-	Inherits: SpawnVisc
-	Warhead@5Actor: SpawnActor
-		Actors: berserker
-
 SlimeAttack:
 	Inherits: ^RifleWarhead
 	ReloadDelay: 80

--- a/mods/sp/weapons/scrweapons.yaml
+++ b/mods/sp/weapons/scrweapons.yaml
@@ -167,7 +167,7 @@ ColossiBlastTesla:
 	Warhead@2Eff: CreateEffect
 		Explosions: lightningexplo
 		ExplosionPalette: apollightbluealpha
-		InvalidTargets:: Water
+		InvalidTargets: Water
 
 DummySparks:
 	Inherits: ColossiTesla
@@ -295,13 +295,48 @@ MindController:
 	ValidTargets: Vehicle
 	InvalidTargets: MCImmune, MindControlInmune
 	Report: iyurat1a.wav
-	Projectile: InstantHit
+	Projectile: ArcLaserZap
 		Blockable: false
+		ZOffset: 1000
+		Width: 50
+		Duration: 10
+		Color: FF666670
+		HitAnim: explosion
+		HitAnimSequence: cldrngl1
+		HitAnimPalette: apolredalpha
 	Warhead@1Dam: SpreadDamage
 		Spread: 1
 		Damage: 0
 		ValidTargets: Infantry, Vehicle
 		InvalidTargets: Structure, Wall, Husk, Trees, Creep, MCImmune, MindControlInmune
+	Warhead@2Eff: CreateEffect
+		Explosions: cldrngl1
+		ExplosionPalette: apolredalpha
+		Delay: 15
+
+MindEnergyCasing:
+	ReloadDelay: 200000
+	Burst: 2
+	Projectile: AthenaProjectile
+		Altitude: 800
+	ValidTargets: Infantry, Vehicle, Building, Wall, Ground, Water, Air, AirHit
+	Warhead@0Dam: TargetDamage
+		ValidTargets: Infantry, Vehicle, Building, Wall, Ground, Water, Air, AirHit
+	Warhead@op: FireShrapnel
+		Weapon: RedSpark
+		ImpactActors: false
+		Amount: 2
+		ValidTargets: Ground, Water, Air, AirHit
+		InvalidTargets: Infantry, Vehicle, Building, Wall
+
+RedSpark:
+	Inherits: ^NoDamage
+	ReloadDelay: 80
+	Range: 1c0
+	Projectile: TeslaZap
+		Palette: apolredalpha
+	Warhead@1Dam: TargetDamage
+		ImpactActors: false
 
 VanguardShrapnel:
 	ReloadDelay: 50


### PR DESCRIPTION
1. Add a ^NonBuildingStaticActor for Polish mines and eggs. avoid flaws on ^BasicVehicle meanwhile this can be template for any non-building visible actor that don't move (you have to add conditional effect to those actor yourself, however)

2. Polish ^GroundDummy to best performance as a static invisible timer.